### PR TITLE
Atualizar testes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,22 +4,16 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 3.1
-  TargetRailsVersion: 7.0
   NewCops: enable
   Exclude:
   - 'bin/**/*'
   - 'vendor/**/*'
   - 'db/**/*'
 
-Documentation:
+Style/Documentation:
   Enabled: false
-
 Style/HashSyntax:
   Enabled: false
-
-Metrics/BlockLength:
-  IgnoredMethods: ['describe', 'context']
 
 Layout/LineLength:
   Exclude:
@@ -27,12 +21,7 @@ Layout/LineLength:
 
 RSpec/ExampleLength:
   Max: 40
-
 RSpec/MultipleExpectations:
   Enabled: false
-
-RSpec/FilePath:
-  Enabled: false
-
 RSpec/ContextWording:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,9 +6,9 @@ require:
 AllCops:
   NewCops: enable
   Exclude:
-  - 'bin/**/*'
-  - 'vendor/**/*'
-  - 'db/**/*'
+  - bin/**/*
+  - vendor/**/*
+  - db/**/*
 
 Style/Documentation:
   Enabled: false
@@ -17,7 +17,7 @@ Style/HashSyntax:
 
 Layout/LineLength:
   Exclude:
-    - 'config/initializers/devise.rb'
+    - config/initializers/devise.rb
 
 RSpec/ExampleLength:
   Max: 40

--- a/Gemfile
+++ b/Gemfile
@@ -24,20 +24,20 @@ gem 'devise'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem 'capybara'
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
-  gem 'rspec-rails'
-  gem 'rubocop-performance'
-  gem 'rubocop-rails'
-  gem 'rubocop-rspec'
 end
 
 group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  gem 'rubocop-performance'
+  gem 'rubocop-rails'
+  gem 'rubocop-rspec'
 end
 
 group :test do
+  gem 'capybara'
+  gem 'rspec-rails'
   gem 'shoulda-matchers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,10 +138,8 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
-    phlex (0.1.0)
-      activesupport (~> 7.0)
     public_suffix (5.0.0)
-    puma (5.6.4)
+    puma (5.6.5)
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.4)
@@ -199,7 +197,7 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.0)
-    rubocop (1.35.0)
+    rubocop (1.36.0)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.2.1)
@@ -254,7 +252,6 @@ DEPENDENCIES
   debug
   devise
   factory_bot_rails
-  phlex
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.4)
   rspec-rails

--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
 # Sistema de gerenciamento de entregas
-Aplicação desenvolvida no âmbito da Turma 8 do **[TreinaDev](https://treinadev.com.br/)** para gerenciar entregas de produtos. Permite:
+
+Aplicação desenvolvida no âmbito da Turma 8 do [**TreinaDev**](<https://treinadev.com.br/>) para gerenciar entregas de produtos. Permite:
+
 - Cadastrar transportadoras, seus veículos e suas tabelas de preços e prazos;
 - Criar ordens de serviço, pesquisar preços e prazos praticados pelas transportadoras para aquela ordem e atribuí-la a uma transportadora;
 - Aceitar ordens de serviço atribuídas à transportadora e atualizar periodicamente situação da entrega;
 - Consultar situação de entrega sendo realizada.
 
-**[Projeto associado no GitHub Projects](https://github.com/users/mfornaciari/projects/1)**
+[**Projeto associado no GitHub Projects**](https://github.com/users/mfornaciari/projects/1)
 
 ## Requisitos
-- [Ruby 3.1.2 +](https://docs.ruby-lang.org/en/3.1/)
-- [Rails 7.0.3 +](https://api.rubyonrails.org/)
-- [rspec-rails 5.1.2 +](https://relishapp.com/rspec/rspec-rails/docs)
-- [capybara 3.37.1 +](https://rubydoc.info/github/teamcapybara/capybara/master)
-- [devise 4.8.1 +](https://github.com/heartcombo/devise)
+
+- [**Ruby 3.1.2 +**](https://docs.ruby-lang.org/en/3.1/)
+- [**Rails 7.0.3 +**](https://api.rubyonrails.org/)
+- [**rspec-rails 5.1.2 +**](https://relishapp.com/rspec/rspec-rails/docs)
+- [**capybara 3.37.1 +**](https://rubydoc.info/github/teamcapybara/capybara/master)
+- [**devise 4.8.1 +**](https://github.com/heartcombo/devise)
 
 ## Executando a aplicação
+
 1. Certifique-se de ter a versão correta do Ruby (3.1.2 +) instalada.
 2. Clone o repositório ou baixe o arquivo .zip e descompacte-o.
 3. Mude de diretório para a pasta principal do projeto.
@@ -24,6 +28,7 @@ Aplicação desenvolvida no âmbito da Turma 8 do **[TreinaDev](https://treinade
 7. Acesse o endereço `localhost:3000` no navegador de sua preferência.
 
 ## Executando testes
+
 1. Certifique-se de ter a versão correta do Ruby (3.1.2 +) instalada.
 2. Clone o repositório ou baixe o arquivo .zip e descompacte-o.
 3. Mude de diretório para a pasta principal do projeto.

--- a/app/models/budget_search.rb
+++ b/app/models/budget_search.rb
@@ -3,7 +3,8 @@
 class BudgetSearch < ApplicationRecord
   belongs_to :admin
 
-  validates :height, :width, :depth, :weight, :distance, comparison: { greater_than: 0 }
+  validates :height, :width, :depth, :weight, :distance, presence: true
+  validates :height, :width, :depth, :weight, :distance, numericality: { greater_than: 0 }
 
   before_create :set_volume_in_cubic_meters
 

--- a/app/models/price_distance_range.rb
+++ b/app/models/price_distance_range.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class PriceDistanceRange < ApplicationRecord
-  validates :value, presence: true
-  validates :min_distance, comparison: { greater_than_or_equal_to: 0 }
-  validates :max_distance, comparison: { greater_than: 0 }
+  belongs_to :shipping_company
+
+  validates :value, :min_distance, :max_distance, presence: true
+  validates :min_distance, numericality: { greater_than_or_equal_to: 0 }
+  validates :max_distance, numericality: { greater_than: 0 }
   validate :not_previously_registered
   validate :min_distance_less_than_max_distance
-
-  belongs_to :shipping_company
 
   private
 

--- a/app/models/route_update.rb
+++ b/app/models/route_update.rb
@@ -2,9 +2,9 @@
 
 class RouteUpdate < ApplicationRecord
   validates :date_and_time, :latitude, :longitude, presence: true
-  validates :latitude, inclusion: { in: -90..90, message: I18n.t('latitude_validation_error') }
-  validates :longitude, inclusion: { in: -180..180, message: I18n.t('longitude_validation_error') }
-  validate :not_future
+  validates :latitude, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }
+  validates :longitude, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
+  validates :date_and_time, comparison: { less_than_or_equal_to: proc { Time.zone.now } }
   validate :after_last_update
 
   belongs_to :order
@@ -20,11 +20,5 @@ class RouteUpdate < ApplicationRecord
       message = 'não podem ser anteriores à última atualização'
       errors.add(:date_and_time, message) if date_and_time < update.date_and_time
     end
-  end
-
-  def not_future
-    return unless date_and_time
-
-    errors.add :date_and_time, message: 'não podem estar no futuro' if date_and_time > Time.current
   end
 end

--- a/app/models/route_update.rb
+++ b/app/models/route_update.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class RouteUpdate < ApplicationRecord
+  belongs_to :order
+
   validates :date_and_time, :latitude, :longitude, presence: true
   validates :latitude, numericality: { greater_than_or_equal_to: -90, less_than_or_equal_to: 90 }
   validates :longitude, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
   validates :date_and_time, comparison: { less_than_or_equal_to: proc { Time.zone.now } }
   validate :after_last_update
-
-  belongs_to :order
 
   private
 

--- a/app/models/shipping_company.rb
+++ b/app/models/shipping_company.rb
@@ -22,7 +22,7 @@ class ShippingCompany < ApplicationRecord
 
   def delivery_time(distance:)
     time_distance_ranges.find_by('min_distance <= :distance AND max_distance >= :distance',
-                                 distance:)&.delivery_time
+                                 distance: distance)&.delivery_time
   end
 
   def value(volume:, weight:, distance:)
@@ -30,18 +30,18 @@ class ShippingCompany < ApplicationRecord
                                                                 max_weight >= :weight AND
                                                                 volume_ranges.min_volume <= :volume AND
                                                                 volume_ranges.max_volume >= :volume',
-                                                                volume:, weight:)&.value
+                                                                volume: volume, weight: weight)&.value
     return if standard_value.nil?
 
     standard_value *= distance
-    min_value = min_value(distance:)
-    min_value > standard_value ? min_value : standard_value
+    min_value = min_value(distance: distance)
+    min_value && min_value > standard_value ? min_value : standard_value
   end
 
   private
 
   def min_value(distance:)
     price_distance_ranges.find_by('min_distance <= :distance AND max_distance >= :distance',
-                                  distance:)&.value
+                                  distance: distance)&.value
   end
 end

--- a/app/models/time_distance_range.rb
+++ b/app/models/time_distance_range.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class TimeDistanceRange < ApplicationRecord
-  validates :delivery_time, presence: true
+  belongs_to :shipping_company
+
+  validates :delivery_time, :min_distance, :max_distance, presence: true
   validates :delivery_time, uniqueness: { scope: :shipping_company_id }
-  validates :min_distance, comparison: { greater_than_or_equal_to: 0 }
-  validates :max_distance, comparison: { greater_than: 0 }
+  validates :min_distance, numericality: { greater_than_or_equal_to: 0 }
+  validates :max_distance, numericality: { greater_than: 0 }
   validate :not_previously_registered
   validate :min_distance_less_than_max_distance
-
-  belongs_to :shipping_company
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,11 +6,11 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  belongs_to :shipping_company, optional: true
-
-  before_validation :set_shipping_company
+  belongs_to :shipping_company
 
   validate :company_exists
+
+  before_validation :set_shipping_company
 
   private
 

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Vehicle < ApplicationRecord
-  validates :model, :brand, :production_year, presence: true
-  validates :license_plate, format: { with: /\A[a-z]{3}\d[\d|[a-z]]\d{2}\z/i }
+  validates :model, :brand, :production_year, :license_plate, :maximum_load, presence: true
   validates :license_plate, uniqueness: true
-  validates :maximum_load, comparison: { greater_than: 0 }
+  validates :license_plate, format: { with: /\A[a-z]{3}\d[\d|[a-z]]\d{2}\z/i }
+  validates :maximum_load, numericality: { greater_than: 0 }
 
   validate :produced_in_valid_years
 

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 class Vehicle < ApplicationRecord
+  belongs_to :shipping_company
+  has_one :order, dependent: :nullify
+
   validates :model, :brand, :production_year, :license_plate, :maximum_load, presence: true
   validates :license_plate, uniqueness: true
   validates :license_plate, format: { with: /\A[a-z]{3}\d[\d|[a-z]]\d{2}\z/i }
   validates :maximum_load, numericality: { greater_than: 0 }
-
   validate :produced_in_valid_years
-
-  belongs_to :shipping_company
-  has_one :order, dependent: :nullify
 
   private
 

--- a/app/models/volume_range.rb
+++ b/app/models/volume_range.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class VolumeRange < ApplicationRecord
+  belongs_to :shipping_company
+  has_many :weight_ranges, dependent: :destroy
+
   validates :min_volume, :max_volume, presence: true
   validates :min_volume, numericality: { greater_than_or_equal_to: 0 }
   validates :max_volume, numericality: { greater_than: 0 }
   validate :not_previously_registered
   validate :min_volume_less_than_max_volume
 
-  belongs_to :shipping_company
-  has_many :weight_ranges, dependent: :destroy
   accepts_nested_attributes_for :weight_ranges
 
   private

--- a/app/models/volume_range.rb
+++ b/app/models/volume_range.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class VolumeRange < ApplicationRecord
-  validates :min_volume, comparison: { greater_than_or_equal_to: 0 }
-  validates :max_volume, comparison: { greater_than: 0 }
+  validates :min_volume, :max_volume, presence: true
+  validates :min_volume, numericality: { greater_than_or_equal_to: 0 }
+  validates :max_volume, numericality: { greater_than: 0 }
   validate :not_previously_registered
   validate :min_volume_less_than_max_volume
 

--- a/app/models/weight_range.rb
+++ b/app/models/weight_range.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class WeightRange < ApplicationRecord
+  belongs_to :volume_range
+
   validates :min_weight, :max_weight, :value, presence: true
   validates :min_weight, numericality: { greater_than_or_equal_to: 0 }
   validates :max_weight, numericality: { greater_than: 0 }
   validate :not_previously_registered
   validate :min_weight_less_than_max_weight
-
-  belongs_to :volume_range
 
   private
 

--- a/app/models/weight_range.rb
+++ b/app/models/weight_range.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class WeightRange < ApplicationRecord
-  validates :value, presence: true
-  validates :min_weight, comparison: { greater_than_or_equal_to: 0 }
-  validates :max_weight, comparison: { greater_than: 0 }
+  validates :min_weight, :max_weight, :value, presence: true
+  validates :min_weight, numericality: { greater_than_or_equal_to: 0 }
+  validates :max_weight, numericality: { greater_than: 0 }
   validate :not_previously_registered
   validate :min_weight_less_than_max_weight
 

--- a/config/locales/models/order.pt-BR.yml
+++ b/config/locales/models/order.pt-BR.yml
@@ -25,7 +25,7 @@ pt-BR:
         delivery_address: Endereço de entrega
         delivery_city: Cidade de entrega
         delivery_state: Estado de entrega
-        recipient_name: Nome(a) do destinatário(a)
+        recipient_name: Nome(a) do(a) destinatário(a)
         product_code: Código do produto
         code: Código
         shipping_company: Transportadora

--- a/config/locales/models/route_update.pt-BR.yml
+++ b/config/locales/models/route_update.pt-BR.yml
@@ -1,8 +1,6 @@
 pt-BR:
   route_update_succeeded_message: Rota de entrega do pedido atualizada.
   route_update_failed_message: Rota de entrega não atualizada.
-  latitude_validation_error: deve estar entre -90 e 90
-  longitude_validation_error: deve estar entre -180 e 180
   activerecord:
     models:
       route_update: Atualização de rota

--- a/db/migrate/20220824234643_add_index_to_time_distance_ranges.rb
+++ b/db/migrate/20220824234643_add_index_to_time_distance_ranges.rb
@@ -1,0 +1,9 @@
+class AddIndexToTimeDistanceRanges < ActiveRecord::Migration[7.0]
+  def up
+    add_index :time_distance_ranges, %i[delivery_time shipping_company_id], unique: true, name: 'index_td_ranges_on_delivery_time_and_company_id'
+  end
+
+  def down
+    remove_index :time_distance_ranges, %i[delivery_time shipping_company_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_21_213837) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_24_234643) do
   create_table "addresses", force: :cascade do |t|
     t.string "line1"
     t.string "city"
@@ -104,6 +104,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_21_213837) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "shipping_company_id", null: false
+    t.index ["delivery_time", "shipping_company_id"], name: "index_td_ranges_on_delivery_time_and_company_id", unique: true
     t.index ["shipping_company_id"], name: "index_time_distance_ranges_on_shipping_company_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -202,6 +202,18 @@ FactoryBot.create :address,
                   city: 'Aracaju',
                   state: :SE
 
+# ATUALIZAÇÕES DE TRAJETO do primeiro pedido
+FactoryBot.create :route_update,
+                  order: order1,
+                  date_and_time: 5.days.ago,
+                  latitude: 45.0,
+                  longitude: 90.0
+FactoryBot.create :route_update,
+                  order: order1,
+                  date_and_time: 1.day.ago,
+                  latitude: 50.0,
+                  longitude: 130.5
+
 # SEGUNDO pedido
 order2 = FactoryBot.create :order,
                            :without_addresses,
@@ -228,15 +240,3 @@ FactoryBot.create :address,
                   line1: 'Rua Mar Roxo, n. 210',
                   city: 'São Luís',
                   state: :MA
-
-# ATUALIZAÇÕES DE TRAJETO do primeiro pedido
-FactoryBot.create :route_update,
-                  order: order1,
-                  date_and_time: 5.days.ago,
-                  latitude: 45.0,
-                  longitude: 90.0
-FactoryBot.create :route_update,
-                  order: order1,
-                  date_and_time: 1.day.ago,
-                  latitude: 50.0,
-                  longitude: 130.5

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :address do
     kind { :company }
     association :addressable, factory: :express
-    sequence(:line1) { |n| "Rua Rio Verde, #{n}" }
+    sequence(:line1) { |number| "Rua Rio Verde, #{number}" }
     city { 'Rio de Janeiro' }
     state { :RJ }
 

--- a/spec/factories/budget_search.rb
+++ b/spec/factories/budget_search.rb
@@ -7,6 +7,6 @@ FactoryBot.define do
     depth { 100 }
     weight { 5 }
     distance { 50 }
-    association :admin
+    admin
   end
 end

--- a/spec/factories/order.rb
+++ b/spec/factories/order.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :order do
-    association :shipping_company, factory: :express
+    for_express
     pickup_address { association :address, addressable: instance, kind: :pickup }
     delivery_address { association :address, addressable: instance, kind: :delivery }
     recipient_name { 'João da Silva' }
@@ -16,6 +16,14 @@ FactoryBot.define do
     trait :without_addresses do
       pickup_address { nil }
       delivery_address { nil }
+    end
+
+    trait :for_express do
+      association :shipping_company, factory: :express
+    end
+
+    trait :for_a_jato do
+      association :shipping_company, factory: :a_jato
     end
   end
 end

--- a/spec/factories/price_distance_range.rb
+++ b/spec/factories/price_distance_range.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     min_distance { 0 }
     max_distance { 1_000 }
     value { 5_000 }
-    association :shipping_company
+    association :shipping_company, factory: :express
   end
 end

--- a/spec/factories/route_update.rb
+++ b/spec/factories/route_update.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     date_and_time { 1.day.ago }
     latitude { 90 }
     longitude { 180 }
-    association :order
+    order
   end
 end

--- a/spec/factories/time_distance_range.rb
+++ b/spec/factories/time_distance_range.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     min_distance { 0 }
     max_distance { 100 }
     delivery_time { 2 }
-    association :shipping_company
+    association :shipping_company, factory: :express
   end
 end

--- a/spec/factories/vehicle.rb
+++ b/spec/factories/vehicle.rb
@@ -7,6 +7,6 @@ FactoryBot.define do
     model { 'Uno' }
     production_year { 1992 }
     maximum_load { 100_000 }
-    association :shipping_company
+    association :shipping_company, factory: :express
   end
 end

--- a/spec/factories/volume_range.rb
+++ b/spec/factories/volume_range.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :volume_range do
     min_volume { 0 }
     max_volume { 20 }
-    association :shipping_company
+    association :shipping_company, factory: :express
   end
 end

--- a/spec/factories/weight_range.rb
+++ b/spec/factories/weight_range.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     min_weight { 0 }
     max_weight { 20 }
     value { 50 }
-    association :volume_range
+    volume_range
   end
 end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe Address, type: :model do
 
   it { is_expected.to belong_to(:addressable) }
 
-  it { is_expected.to validate_presence_of(:line1) }
-  it { is_expected.to validate_presence_of(:city) }
-  it { is_expected.to validate_presence_of(:state) }
+  it { is_expected.to validate_presence_of(:line1).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:city).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:state).with_message('não pode ficar em branco') }
 
   describe '#full_address' do
     subject do

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -3,17 +3,6 @@
 require 'rails_helper'
 
 RSpec.describe Admin, type: :model do
-  describe '#valid?' do
-    context 'Valor:' do
-      it 'Falso quando domínio de e-mail está incorreto' do
-        invalid_admin = described_class.new(email: 'admin@email.com')
-        valid_admin = described_class.new(email: 'admin@sistemadefrete.com.br')
-
-        [invalid_admin, valid_admin].each(&:valid?)
-
-        expect(invalid_admin.errors[:email]).to include 'não é válido'
-        expect(valid_admin.errors.include?(:email)).to be false
-      end
-    end
-  end
+  it { is_expected.not_to allow_value('admin@gmail.com').for(:email).with_message('não é válido') }
+  it { is_expected.to allow_value('admin@sistemadefrete.com.br').for(:email) }
 end

--- a/spec/models/budget_search_spec.rb
+++ b/spec/models/budget_search_spec.rb
@@ -3,76 +3,23 @@
 require 'rails_helper'
 
 RSpec.describe BudgetSearch, type: :model do
-  describe '#valid?' do
-    context 'Valor:' do
-      it 'Falso quando altura está em branco ou é <= 0' do
-        empty_search = described_class.new(height: '')
-        invalid_search = described_class.new(height: 0)
-        valid_search = described_class.new(height: 1)
+  it { is_expected.to belong_to(:admin) }
 
-        [empty_search, invalid_search, valid_search].each(&:valid?)
+  it { is_expected.to validate_presence_of(:height).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:width).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:depth).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:weight).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:distance).with_message('não pode ficar em branco') }
 
-        expect(empty_search.errors[:height]).to include 'não pode ficar em branco'
-        expect(invalid_search.errors[:height]).to include 'deve ser maior que 0'
-        expect(valid_search.errors.include?(:height)).to be false
-      end
-
-      it 'Falso quando largura está em branco ou é <= 0' do
-        empty_search = described_class.new(width: '')
-        invalid_search = described_class.new(width: 0)
-        valid_search = described_class.new(width: 1)
-
-        [empty_search, invalid_search, valid_search].each(&:valid?)
-
-        expect(empty_search.errors[:width]).to include 'não pode ficar em branco'
-        expect(invalid_search.errors[:width]).to include 'deve ser maior que 0'
-        expect(valid_search.errors.include?(:width)).to be false
-      end
-
-      it 'Falso quando profundidade está em branco ou é <= 0' do
-        empty_search = described_class.new(depth: '')
-        invalid_search = described_class.new(depth: 0)
-        valid_search = described_class.new(depth: 1)
-
-        [empty_search, invalid_search, valid_search].each(&:valid?)
-
-        expect(empty_search.errors[:depth]).to include 'não pode ficar em branco'
-        expect(invalid_search.errors[:depth]).to include 'deve ser maior que 0'
-        expect(valid_search.errors.include?(:depth)).to be false
-      end
-
-      it 'Falso quando peso está em branco ou é <= 0' do
-        empty_search = described_class.new(weight: '')
-        invalid_search = described_class.new(weight: 0)
-        valid_search = described_class.new(weight: 1)
-
-        [empty_search, invalid_search, valid_search].each(&:valid?)
-
-        expect(empty_search.errors[:weight]).to include 'não pode ficar em branco'
-        expect(invalid_search.errors[:weight]).to include 'deve ser maior que 0'
-        expect(valid_search.errors.include?(:weight)).to be false
-      end
-
-      it 'Falso quando distância está em branco ou é <= 0' do
-        empty_search = described_class.new(distance: '')
-        invalid_search = described_class.new(distance: 0)
-        valid_search = described_class.new(distance: 1)
-
-        [empty_search, invalid_search, valid_search].each(&:valid?)
-
-        expect(empty_search.errors[:distance]).to include 'não pode ficar em branco'
-        expect(invalid_search.errors[:distance]).to include 'deve ser maior que 0'
-        expect(valid_search.errors.include?(:distance)).to be false
-      end
-    end
-  end
+  it { is_expected.to validate_numericality_of(:height).is_greater_than(0) }
+  it { is_expected.to validate_numericality_of(:width).is_greater_than(0) }
+  it { is_expected.to validate_numericality_of(:depth).is_greater_than(0) }
+  it { is_expected.to validate_numericality_of(:weight).is_greater_than(0) }
+  it { is_expected.to validate_numericality_of(:distance).is_greater_than(0) }
 
   describe '#set_volume_in_cubic_meters' do
-    it 'deve definir volume em m³ multiplicando altura, largura e profundidade em cm' do
-      admin = create :admin
-      search = create :budget_search, height: 100, width: 100, depth: 100, admin: admin
+    subject(:volume) { (create :budget_search, height: 100, width: 100, depth: 100).volume }
 
-      expect(search.volume).to eq 1
-    end
+    it { is_expected.to eq 1 }
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Order, type: :model do
   it { is_expected.to validate_presence_of(:product_code).with_message('não pode ficar em branco') }
 
   describe '#generate_code' do
-    subject(:order) { create :order, :for_express }
+    let(:order) { create :order, :for_express }
 
     it 'must create a 15-character alphanumeric code' do
       expect(order.code).to match(/\A[[:alnum:]]{15}\z/)

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -6,32 +6,25 @@ RSpec.describe Order, type: :model do
   it { is_expected.to have_one(:pickup_address) }
   it { is_expected.to have_one(:delivery_address) }
 
-  it { is_expected.to validate_presence_of(:recipient_name) }
-  it { is_expected.to validate_presence_of(:product_code) }
+  it { is_expected.to validate_presence_of(:recipient_name).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:product_code).with_message('não pode ficar em branco') }
 
-  describe 'Gera um código aleatório' do
-    it 'ao criar um novo pedido' do
-      order = create :order
+  describe '#generate_code' do
+    subject(:order) { create :order, :for_express }
 
-      order.save!
-
-      expect(order.code).not_to be_empty
-      expect(order.code.length).to eq 15
+    it 'creates 15 character alphanumeric code' do
+      expect(order.code).to match(/\A[[:alnum:]]{15}\z/)
     end
 
-    it 'e ele é único' do
-      order1 = create :order
-      order2 = create :order, shipping_company: order1.shipping_company
+    it 'creates unique code' do
+      new_order = create :order, :for_a_jato
 
-      order2.save!
-
-      expect(order2.code).not_to eq order1.code
+      expect(order.code).not_to eq new_order.code
     end
 
-    it 'e ele não muda após atualização' do
-      order = create :order
-
+    it 'creates code that does not change on update' do
       original_code = order.code
+
       order.accepted!
 
       expect(order.code).to eq original_code

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -12,17 +12,17 @@ RSpec.describe Order, type: :model do
   describe '#generate_code' do
     subject(:order) { create :order, :for_express }
 
-    it 'creates 15 character alphanumeric code' do
+    it 'must create a 15-character alphanumeric code' do
       expect(order.code).to match(/\A[[:alnum:]]{15}\z/)
     end
 
-    it 'creates unique code' do
+    it 'must create a unique code' do
       new_order = create :order, :for_a_jato
 
       expect(order.code).not_to eq new_order.code
     end
 
-    it 'creates code that does not change on update' do
+    it 'must create a code that does not change on update' do
       original_code = order.code
 
       order.accepted!

--- a/spec/models/price_distance_range_spec.rb
+++ b/spec/models/price_distance_range_spec.rb
@@ -25,7 +25,9 @@ RSpec.describe PriceDistanceRange, type: :model do
     subject(:pd_range) { build :price_distance_range }
 
     before do
-      create :price_distance_range, shipping_company: pd_range.shipping_company, min_distance: 0, max_distance: 2
+      create :price_distance_range, shipping_company: pd_range.shipping_company,
+                                    min_distance: 0,
+                                    max_distance: 2
       pd_range.shipping_company.reload
     end
 

--- a/spec/models/price_distance_range_spec.rb
+++ b/spec/models/price_distance_range_spec.rb
@@ -3,87 +3,43 @@
 require 'rails_helper'
 
 RSpec.describe PriceDistanceRange, type: :model do
-  describe '#valid?' do
-    context 'Presença:' do
-      it 'Falso quando transportadora está em branco' do
-        drange = described_class.new(shipping_company: nil)
+  subject(:pd_range) { build :price_distance_range }
 
-        drange.valid?
+  it { is_expected.to belong_to(:shipping_company) }
 
-        expect(drange.errors[:shipping_company]).to include 'é obrigatório(a)'
-      end
+  it { is_expected.to validate_presence_of(:value).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:min_distance).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:max_distance).with_message('não pode ficar em branco') }
 
-      it 'Falso quando valor está em branco' do
-        drange = described_class.new(value: '')
+  it { is_expected.to validate_numericality_of(:min_distance).is_greater_than_or_equal_to(0) }
+  it { is_expected.to validate_numericality_of(:max_distance).is_greater_than(0) }
 
-        drange.valid?
+  it 'must not allow minimum distance to be >= maximum distance' do
+    range = build :price_distance_range, max_distance: 5
 
-        expect(drange.errors[:value]).to include 'não pode ficar em branco'
-      end
+    expect(range).not_to allow_values(5, 6).for(:min_distance).with_message('deve ser menor que distância máxima')
+    expect(range).to allow_value(4).for(:min_distance)
+  end
+
+  context 'must not allow repetition' do
+    subject(:pd_range) { build :price_distance_range }
+
+    before do
+      create :price_distance_range, shipping_company: pd_range.shipping_company, min_distance: 0, max_distance: 2
+      pd_range.shipping_company.reload
     end
 
-    context 'Valor:' do
-      it 'Falso quando distância mínima está em branco ou é < 0' do
-        empty_range = described_class.new(min_distance: '')
-        invalid_range = described_class.new(min_distance: -1)
-        valid_range = described_class.new(min_distance: 0)
-
-        [empty_range, invalid_range, valid_range].each(&:valid?)
-
-        expect(empty_range.errors[:min_distance]).to include 'não pode ficar em branco'
-        expect(invalid_range.errors[:min_distance]).to include 'deve ser maior ou igual a 0'
-        expect(valid_range.errors.include?(:min_distance)).to be false
-      end
-
-      it 'Falso quando distância máxima está em branco ou é < 1' do
-        empty_range = described_class.new(max_distance: '')
-        invalid_range = described_class.new(max_distance: 0)
-        valid_range = described_class.new(max_distance: 1)
-
-        [empty_range, invalid_range, valid_range].each(&:valid?)
-
-        expect(empty_range.errors[:max_distance]).to include 'não pode ficar em branco'
-        expect(invalid_range.errors[:max_distance]).to include 'deve ser maior que 0'
-        expect(valid_range.errors.include?(:max_distance)).to be false
-      end
-
-      it 'Falso quando distância mínima >= distância máxima' do
-        first_invalid_range = described_class.new(min_distance: 5, max_distance: 5)
-        second_invalid_range = described_class.new(min_distance: 6, max_distance: 5)
-
-        [first_invalid_range, second_invalid_range].each(&:valid?)
-
-        expect(first_invalid_range.errors[:min_distance]).to include 'deve ser menor que distância máxima'
-        expect(second_invalid_range.errors[:min_distance]).to include 'deve ser menor que distância máxima'
-      end
+    it 'of minimum distance' do
+      expect(pd_range).not_to allow_values(0, 1, 2)
+        .for(:min_distance).with_message('não pode estar contida em intervalos já registrados')
     end
 
-    context 'Singularidade:' do
-      it 'Falso quando distância mínima está inclusa em intervalos já cadastrados' do
-        express = create :express
-        create :price_distance_range, shipping_company: express, min_distance: 0, max_distance: 100
-        invalid_range = described_class.new(shipping_company: express, min_distance: 0)
-        valid_range = described_class.new(shipping_company: express, min_distance: 101)
-
-        express.reload
-        [invalid_range, valid_range].each(&:valid?)
-
-        expect(invalid_range.errors[:min_distance]).to include('não pode estar contida em intervalos já registrados')
-        expect(valid_range.errors.include?(:min_distance)).to be false
-      end
-
-      it 'Falso quando distância máxima está inclusa em intervalos já cadastrados' do
-        express = create :express
-        create :price_distance_range, shipping_company: express, min_distance: 0, max_distance: 100
-        invalid_range = described_class.new(shipping_company: express, max_distance: 100)
-        valid_range = described_class.new(shipping_company: express, max_distance: 101)
-
-        express.reload
-        [invalid_range, valid_range].each(&:valid?)
-
-        expect(invalid_range.errors[:max_distance]).to include('não pode estar contida em intervalos já registrados')
-        expect(valid_range.errors.include?(:max_distance)).to be false
-      end
+    it 'of maximum distance' do
+      expect(pd_range).not_to allow_values(1, 2)
+        .for(:max_distance).with_message('não pode estar contida em intervalos já registrados')
     end
+
+    it { is_expected.to allow_value(3).for(:min_distance) }
+    it { is_expected.to allow_value(3).for(:max_distance) }
   end
 end

--- a/spec/models/route_update_spec.rb
+++ b/spec/models/route_update_spec.rb
@@ -3,88 +3,33 @@
 require 'rails_helper'
 
 RSpec.describe RouteUpdate, type: :model do
-  describe '#valid?' do
-    context 'Presença:' do
-      it 'Falso quando data e hora estão em branco' do
-        route_update = described_class.new(date_and_time: '')
+  subject(:route_update) { build :route_update }
 
-        route_update.valid?
+  it { is_expected.to belong_to(:order) }
 
-        expect(route_update.errors[:date_and_time]).to include 'não pode ficar em branco'
-      end
+  it { is_expected.to validate_presence_of(:date_and_time).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:latitude).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:longitude).with_message('não pode ficar em branco') }
 
-      it 'Falso quando latitude está em branco' do
-        route_update = described_class.new(latitude: '')
+  it 'latitude value validation' do
+    expect(route_update).to validate_numericality_of(:latitude)
+      .is_greater_than_or_equal_to(-90).is_less_than_or_equal_to(90)
+  end
 
-        route_update.valid?
+  it 'longitude value validation' do
+    expect(route_update).to validate_numericality_of(:longitude)
+      .is_greater_than_or_equal_to(-180).is_less_than_or_equal_to(180)
+  end
 
-        expect(route_update.errors[:latitude]).to include 'não pode ficar em branco'
-      end
+  it { is_expected.not_to allow_value(1.second.from_now).for(:date_and_time) }
+  it { is_expected.to allow_value(1.second.ago).for(:date_and_time) }
 
-      it 'Falso quando longitude está em branco' do
-        route_update = described_class.new(longitude: '')
+  it 'must not allow date and time to predate last update' do
+    create :route_update, order: route_update.order, date_and_time: 1.second.ago
 
-        route_update.valid?
+    route_update.order.reload
 
-        expect(route_update.errors[:longitude]).to include 'não pode ficar em branco'
-      end
-
-      it 'Falso quando pedido está em branco' do
-        route_update = described_class.new(order: nil)
-
-        route_update.valid?
-
-        expect(route_update.errors[:order]).to include 'é obrigatório(a)'
-      end
-    end
-
-    context 'Valor:' do
-      it 'Falso quando latitude < -90 ou > 90' do
-        first_invalid_update = described_class.new(latitude: -90.1)
-        second_invalid_update = described_class.new(latitude: 90.1)
-        valid_update = described_class.new(latitude: 90.0)
-
-        [first_invalid_update, second_invalid_update, valid_update].each(&:valid?)
-
-        expect(first_invalid_update.errors[:latitude]).to include 'deve estar entre -90 e 90'
-        expect(second_invalid_update.errors[:latitude]).to include 'deve estar entre -90 e 90'
-        expect(valid_update.errors.include?(:latitude)).to be false
-      end
-
-      it 'Falso quando longitude < -180 ou > 180' do
-        first_invalid_update = described_class.new(longitude: -180.1)
-        second_invalid_update = described_class.new(longitude: 180.1)
-        valid_update = described_class.new(longitude: 90.0)
-
-        [first_invalid_update, second_invalid_update, valid_update].each(&:valid?)
-
-        expect(first_invalid_update.errors[:longitude]).to include 'deve estar entre -180 e 180'
-        expect(second_invalid_update.errors[:longitude]).to include 'deve estar entre -180 e 180'
-        expect(valid_update.errors.include?(:longitude)).to be false
-      end
-
-      it 'Falso quando data e hora > data e hora atuais' do
-        invalid_update = described_class.new(date_and_time: 1.second.from_now)
-        valid_update = described_class.new(date_and_time: 1.second.ago)
-
-        [invalid_update, valid_update].each(&:valid?)
-
-        expect(invalid_update.errors[:date_and_time]).to include 'não podem estar no futuro'
-        expect(valid_update.errors.include?(:date_and_time)).to be false
-      end
-
-      it 'Falso quando data e hora <= última data e hora cadastrada' do
-        express = create :express
-        vehicle = create :vehicle, shipping_company: express
-        order = create :order, shipping_company: express, status: :accepted, vehicle: vehicle
-        create :route_update, order: order, date_and_time: 1.second.ago
-        second_update = described_class.new(order:, date_and_time: 2.seconds.ago)
-
-        order.reload
-        second_update.valid?
-
-        expect(second_update.errors[:date_and_time]).to include 'não podem ser anteriores à última atualização'
-      end
-    end
+    expect(route_update).not_to allow_value(2.seconds.ago)
+      .for(:date_and_time).with_message('não podem ser anteriores à última atualização')
   end
 end

--- a/spec/models/route_update_spec.rb
+++ b/spec/models/route_update_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe RouteUpdate, type: :model do
   it { is_expected.to validate_presence_of(:latitude).with_message('não pode ficar em branco') }
   it { is_expected.to validate_presence_of(:longitude).with_message('não pode ficar em branco') }
 
-  it 'latitude value validation' do
+  it 'must not allow latitude to be < -90 or > 90' do
     expect(route_update).to validate_numericality_of(:latitude)
       .is_greater_than_or_equal_to(-90).is_less_than_or_equal_to(90)
   end
 
-  it 'longitude value validation' do
+  it 'must not allow longitude to be < -180 or > 180' do
     expect(route_update).to validate_numericality_of(:longitude)
       .is_greater_than_or_equal_to(-180).is_less_than_or_equal_to(180)
   end

--- a/spec/models/shipping_company_spec.rb
+++ b/spec/models/shipping_company_spec.rb
@@ -21,14 +21,14 @@ RSpec.describe ShippingCompany, type: :model do
 
   it { is_expected.to validate_uniqueness_of(:registration_number).with_message('já está em uso') }
 
-  it 'e-mail domain format validation' do
+  it 'must not allow incorrect format for e-mail domain' do
     expect(company).not_to allow_values('express', '-express.com.br', 'express.com-')
       .for(:email_domain).with_message('não é válido')
     expect(company).to allow_values('express.com.br', 'ajato.com')
       .for(:email_domain)
   end
 
-  it 'registration number format validation' do
+  it 'must not allow incorrect format for registration number' do
     expect(company).not_to allow_values(8_891_540_000_121, 128_891_540_000_121)
       .for(:registration_number).with_message('não é válido')
     expect(company).to allow_value(28_891_540_000_121)

--- a/spec/models/shipping_company_spec.rb
+++ b/spec/models/shipping_company_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe ShippingCompany, type: :model do
+  subject(:company) { build :shipping_company }
+
   it { is_expected.to have_one(:address) }
   it { is_expected.to have_many(:users) }
   it { is_expected.to have_many(:vehicles) }
@@ -12,15 +14,24 @@ RSpec.describe ShippingCompany, type: :model do
   it { is_expected.to have_many(:time_distance_ranges) }
   it { is_expected.to have_many(:orders) }
 
-  it { is_expected.to validate_presence_of(:brand_name) }
-  it { is_expected.to validate_presence_of(:corporate_name) }
-  it { is_expected.to validate_presence_of(:email_domain) }
-  it { is_expected.to validate_presence_of(:registration_number) }
+  it { is_expected.to validate_presence_of(:brand_name).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:corporate_name).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:email_domain).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:registration_number).with_message('não pode ficar em branco') }
 
-  it { is_expected.not_to allow_values('express', '-express.com.br', 'express.com-').for(:email_domain) }
-  it { is_expected.to allow_values('express.com.br', 'ajato.com').for(:email_domain) }
-  it { is_expected.not_to allow_values(8_891_540_000_121, 128_891_540_000_121).for(:registration_number) }
-  it { is_expected.to allow_value(28_891_540_000_121).for(:registration_number) }
+  it { is_expected.to validate_uniqueness_of(:registration_number).with_message('já está em uso') }
 
-  it { is_expected.to validate_uniqueness_of(:registration_number) }
+  it 'e-mail domain format validation' do
+    expect(company).not_to allow_values('express', '-express.com.br', 'express.com-')
+      .for(:email_domain).with_message('não é válido')
+    expect(company).to allow_values('express.com.br', 'ajato.com')
+      .for(:email_domain)
+  end
+
+  it 'registration number format validation' do
+    expect(company).not_to allow_values(8_891_540_000_121, 128_891_540_000_121)
+      .for(:registration_number).with_message('não é válido')
+    expect(company).to allow_value(28_891_540_000_121)
+      .for(:registration_number)
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe User, type: :model do
 
   let!(:express) { create :express, email_domain: 'express.com.br' }
 
-  it 'e-mail domain validation' do
+  it 'must not allow e-mails with unregistered domains' do
     create :a_jato, email_domain: 'ajato.com'
 
     expect(user).not_to allow_value('usuario@gmail.com')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,33 +3,22 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe '#valid?' do
-    context 'Valor:' do
-      it 'Falso quando domínio de e-mail não está registrado' do
-        create :express, email_domain: 'express.com.br'
-        create :a_jato, email_domain: 'ajato.com'
-        invalid_user = described_class.new(email: 'usuario@email.com')
-        first_valid_user = described_class.new(email: 'usuario@express.com.br')
-        second_valid_user = described_class.new(email: 'usuario@ajato.com')
+  subject(:user) { build :user }
 
-        [invalid_user, first_valid_user, second_valid_user].each(&:valid?)
+  let!(:express) { create :express, email_domain: 'express.com.br' }
 
-        expect(invalid_user.errors[:email]).to include 'não possui um domínio registrado'
-        expect(first_valid_user.errors.include?(:email)).to be false
-        expect(second_valid_user.errors.include?(:email)).to be false
-      end
-    end
+  it 'e-mail domain validation' do
+    create :a_jato, email_domain: 'ajato.com'
+
+    expect(user).not_to allow_value('usuario@gmail.com')
+      .for(:email).with_message('não possui um domínio registrado')
+    expect(user).to allow_values('usuario@express.com.br', 'usuario@ajato.com')
+      .for(:email)
   end
 
   describe '#set_shipping_company' do
-    it 'Deve atribuir transportadora com base no domínio de e-mail' do
-      create :a_jato, email_domain: 'ajato.com'
-      express = create :express, email_domain: 'express.com.br'
-      user = create :user, email: 'usuario@express.com.br'
+    subject(:user_company) { (create :user, email: 'usuario@express.com.br').shipping_company }
 
-      user.valid?
-
-      expect(user.shipping_company).to eq express
-    end
+    it { is_expected.to eq express }
   end
 end

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Vehicle, type: :model do
       .for(:license_plate)
   end
 
-  it 'production year format validation' do
+  it 'production year value validation' do
     expect(vehicle).not_to allow_values(1907, 1.year.from_now.year)
       .for(:production_year).with_message('deve estar entre 1908 e o ano atual')
     expect(vehicle).to allow_value(2022)

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe Vehicle, type: :model do
 
   it { is_expected.to validate_numericality_of(:maximum_load).is_greater_than(0) }
 
-  it 'license plate format validation' do
+  it 'must not allow incorrect format for license plate' do
     expect(vehicle).not_to allow_values('ABCD123', 'ABC12345', 'ABCD1234')
       .for(:license_plate).with_message('não é válido')
     expect(vehicle).to allow_values('ABC1D23', 'ABC1234')
       .for(:license_plate)
   end
 
-  it 'production year value validation' do
+  it 'must not allow production year to be < 1908 or > current year' do
     expect(vehicle).not_to allow_values(1907, 1.year.from_now.year)
       .for(:production_year).with_message('deve estar entre 1908 e o ano atual')
     expect(vehicle).to allow_value(2022)

--- a/spec/models/vehicle_spec.rb
+++ b/spec/models/vehicle_spec.rb
@@ -3,100 +3,31 @@
 require 'rails_helper'
 
 RSpec.describe Vehicle, type: :model do
-  describe '#valid?' do
-    context 'Presença:' do
-      it 'Falso quando modelo está em branco' do
-        vehicle = described_class.new(model: '')
+  subject(:vehicle) { build :vehicle }
 
-        vehicle.valid?
+  it { is_expected.to belong_to(:shipping_company) }
 
-        expect(vehicle.errors[:model]).to include 'não pode ficar em branco'
-      end
+  it { is_expected.to validate_presence_of(:model).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:brand).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:license_plate).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:production_year).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:maximum_load).with_message('não pode ficar em branco') }
 
-      it 'Falso quando marca está em branco' do
-        vehicle = described_class.new(brand: '')
+  it { is_expected.to validate_uniqueness_of(:license_plate).with_message('já está em uso') }
 
-        vehicle.valid?
+  it { is_expected.to validate_numericality_of(:maximum_load).is_greater_than(0) }
 
-        expect(vehicle.errors[:brand]).to include 'não pode ficar em branco'
-      end
+  it 'license plate format validation' do
+    expect(vehicle).not_to allow_values('ABCD123', 'ABC12345', 'ABCD1234')
+      .for(:license_plate).with_message('não é válido')
+    expect(vehicle).to allow_values('ABC1D23', 'ABC1234')
+      .for(:license_plate)
+  end
 
-      it 'Falso quando ano de produção está em branco' do
-        vehicle = described_class.new(production_year: '')
-
-        vehicle.valid?
-
-        expect(vehicle.errors[:production_year]).to include 'não pode ficar em branco'
-      end
-
-      it 'Falso quando transportadora está em branco' do
-        vehicle = described_class.new(shipping_company: nil)
-
-        vehicle.valid?
-
-        expect(vehicle.errors[:shipping_company]).to include 'é obrigatório(a)'
-      end
-    end
-
-    context 'Formato:' do
-      it 'Falso quando placa de identificação está vazia/em formato incorreto' do
-        empty_vehicle = described_class.new(license_plate: '')
-        first_invalid_vehicle = described_class.new(license_plate: 'ABCD123')
-        second_invalid_vehicle = described_class.new(license_plate: 'ABC12345')
-        third_invalid_vehicle = described_class.new(license_plate: 'ABCD1234')
-        first_valid_vehicle = described_class.new(license_plate: 'ABC1D23')
-        second_valid_vehicle = described_class.new(license_plate: 'ABC1234')
-
-        [empty_vehicle, first_invalid_vehicle, second_invalid_vehicle, third_invalid_vehicle,
-         first_valid_vehicle, second_valid_vehicle].each(&:valid?)
-
-        expect(empty_vehicle.errors[:license_plate]).to include 'não é válido'
-        expect(first_invalid_vehicle.errors[:license_plate]).to include 'não é válido'
-        expect(second_invalid_vehicle.errors[:license_plate]).to include 'não é válido'
-        expect(third_invalid_vehicle.errors[:license_plate]).to include 'não é válido'
-        expect(first_valid_vehicle.errors.include?(:license_plate)).to be false
-        expect(second_valid_vehicle.errors.include?(:license_plate)).to be false
-      end
-    end
-
-    context 'Singularidade:' do
-      it 'Falso quando placa de identificação é repetida' do
-        express = create :express
-        create :vehicle, shipping_company: express, license_plate: 'BRA3R52'
-        vehicle = described_class.new(license_plate: 'BRA3R52')
-
-        vehicle.valid?
-
-        expect(vehicle.errors[:license_plate]).to include 'já está em uso'
-      end
-    end
-
-    context 'Valor:' do
-      it 'Falso quando ano de produção é < 1908 ou > ano atual' do
-        first_invalid_vehicle = described_class.new(production_year: 1907)
-        second_invalid_vehicle = described_class.new(production_year: 2023)
-        valid_vehicle = described_class.new(production_year: 2022)
-
-        [first_invalid_vehicle, second_invalid_vehicle, valid_vehicle].each(&:valid?)
-
-        expect(first_invalid_vehicle.errors[:production_year]).to include('deve estar entre 1908 e o ano atual')
-        expect(second_invalid_vehicle.errors[:production_year]).to include('deve estar entre 1908 e o ano atual')
-        expect(valid_vehicle.errors.include?(:production_year)).to be false
-      end
-
-      it 'Falso quando carga máxima está vazia ou é <= 0' do
-        empty_vehicle = described_class.new(maximum_load: '')
-        first_invalid_vehicle = described_class.new(maximum_load: 0)
-        second_invalid_vehicle = described_class.new(maximum_load: -1)
-        valid_vehicle = described_class.new(maximum_load: 100_000)
-
-        [empty_vehicle, first_invalid_vehicle, second_invalid_vehicle, valid_vehicle].each(&:valid?)
-
-        expect(empty_vehicle.errors[:maximum_load]).to include('não pode ficar em branco')
-        expect(first_invalid_vehicle.errors[:maximum_load]).to include('deve ser maior que 0')
-        expect(second_invalid_vehicle.errors[:maximum_load]).to include('deve ser maior que 0')
-        expect(valid_vehicle.errors.include?(:maximum_load)).to be false
-      end
-    end
+  it 'production year format validation' do
+    expect(vehicle).not_to allow_values(1907, 1.year.from_now.year)
+      .for(:production_year).with_message('deve estar entre 1908 e o ano atual')
+    expect(vehicle).to allow_value(2022)
+      .for(:production_year)
   end
 end

--- a/spec/models/volume_range_spec.rb
+++ b/spec/models/volume_range_spec.rb
@@ -3,79 +3,40 @@
 require 'rails_helper'
 
 RSpec.describe VolumeRange, type: :model do
-  describe '#valid?' do
-    context 'Presença:' do
-      it 'Falso quando transportadora está em branco' do
-        vrange = described_class.new(shipping_company: nil)
+  it { is_expected.to belong_to(:shipping_company) }
 
-        vrange.valid?
+  it { is_expected.to validate_presence_of(:min_volume).with_message('não pode ficar em branco') }
+  it { is_expected.to validate_presence_of(:max_volume).with_message('não pode ficar em branco') }
 
-        expect(vrange.errors[:shipping_company]).to include 'é obrigatório(a)'
-      end
+  it { is_expected.to validate_numericality_of(:min_volume).is_greater_than_or_equal_to(0) }
+  it { is_expected.to validate_numericality_of(:max_volume).is_greater_than(0) }
+
+  it 'must not allow minimum volume to be >= maximum volume' do
+    range = build :volume_range, max_volume: 5
+
+    expect(range).not_to allow_values(5, 6).for(:min_volume).with_message('deve ser menor que o volume máximo')
+    expect(range).to allow_value(4).for(:min_volume)
+  end
+
+  context 'must not allow repetition' do
+    subject(:v_range) { build :volume_range }
+
+    before do
+      create :volume_range, shipping_company: v_range.shipping_company, min_volume: 0, max_volume: 2
+      v_range.shipping_company.reload
     end
 
-    context 'Valor:' do
-      it 'Falso quando volume mínimo está em branco ou é < 0' do
-        empty_range = described_class.new(min_volume: '')
-        invalid_range = described_class.new(min_volume: -1)
-        valid_range = described_class.new(min_volume: 0)
-
-        [empty_range, invalid_range, valid_range].each(&:valid?)
-
-        expect(empty_range.errors[:min_volume]).to include 'não pode ficar em branco'
-        expect(invalid_range.errors[:min_volume]).to include 'deve ser maior ou igual a 0'
-        expect(valid_range.errors.include?(:min_volume)).to be false
-      end
-
-      it 'Falso quando volume máximo está em branco ou é < 1' do
-        empty_range = described_class.new(max_volume: '')
-        invalid_range = described_class.new(max_volume: 0)
-        valid_range = described_class.new(max_volume: 1)
-
-        [empty_range, invalid_range, valid_range].each(&:valid?)
-
-        expect(empty_range.errors[:max_volume]).to include 'não pode ficar em branco'
-        expect(invalid_range.errors[:max_volume]).to include 'deve ser maior que 0'
-        expect(valid_range.errors.include?(:max_volume)).to be false
-      end
-
-      it 'Falso quando volume mínimo >= volume máximo' do
-        first_invalid_range = described_class.new(min_volume: 5, max_volume: 5)
-        second_invalid_range = described_class.new(min_volume: 6, max_volume: 5)
-
-        [first_invalid_range, second_invalid_range].each(&:valid?)
-
-        expect(first_invalid_range.errors[:min_volume]).to include 'deve ser menor que o volume máximo'
-        expect(second_invalid_range.errors[:min_volume]).to include 'deve ser menor que o volume máximo'
-      end
+    it 'of minimum volume' do
+      expect(v_range).not_to allow_values(0, 1, 2)
+        .for(:min_volume).with_message('não pode estar contido em intervalos já registrados')
     end
 
-    context 'Singularidade:' do
-      it 'Falso quando volume mínimo está incluso em intervalos já cadastrados' do
-        express = create :express
-        described_class.create!(shipping_company: express, min_volume: 0, max_volume: 20)
-        invalid_range = described_class.new(shipping_company: express, min_volume: 0)
-        valid_range = described_class.new(shipping_company: express, min_volume: 21)
-
-        express.reload
-        [invalid_range, valid_range].each(&:valid?)
-
-        expect(invalid_range.errors[:min_volume]).to include('não pode estar contido em intervalos já registrados')
-        expect(valid_range.errors.include?(:min_volume)).to be false
-      end
-
-      it 'Falso quando volume máximo está incluso em intervalos já cadastrados' do
-        express = create :express
-        described_class.create!(shipping_company: express, min_volume: 0, max_volume: 20)
-        invalid_range = described_class.new(shipping_company: express, max_volume: 20)
-        valid_range = described_class.new(shipping_company: express, max_volume: 40)
-
-        express.reload
-        [invalid_range, valid_range].each(&:valid?)
-
-        expect(invalid_range.errors[:max_volume]).to include('não pode estar contido em intervalos já registrados')
-        expect(valid_range.errors.include?(:max_volume)).to be false
-      end
+    it 'of maximum volume' do
+      expect(v_range).not_to allow_values(1, 2)
+        .for(:max_volume).with_message('não pode estar contido em intervalos já registrados')
     end
+
+    it { is_expected.to allow_value(3).for(:min_volume) }
+    it { is_expected.to allow_value(3).for(:max_volume) }
   end
 end

--- a/spec/system/authentication/admin_logs_in_spec.rb
+++ b/spec/system/authentication/admin_logs_in_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 describe 'Administrador se autentica' do
-  it 'com sucesso' do
-    create :admin, email: 'admin@sistemadefrete.com.br', password: 'password'
+  let!(:admin) { create :admin, email: 'admin@sistemadefrete.com.br', password: 'password' }
 
+  it 'com sucesso' do
     visit root_path
     click_on 'Entrar (administrador)'
     fill_in 'E-mail', with: 'admin@sistemadefrete.com.br'
@@ -17,21 +17,11 @@ describe 'Administrador se autentica' do
     expect(page).to have_content 'admin@sistemadefrete.com.br'
     expect(page).to have_button 'Sair'
     expect(page).to have_link 'Transportadoras'
-  end
-
-  it 'e não vê mais links de autenticação' do
-    admin = create :admin
-
-    login_as admin, scope: :admin
-    visit root_path
-
     expect(page).not_to have_link 'Entrar (administrador)'
     expect(page).not_to have_link 'Entrar (usuário)'
   end
 
   it 'e faz logout' do
-    admin = create :admin
-
     login_as admin, scope: :admin
     visit root_path
     click_on 'Sair'

--- a/spec/system/authentication/user_logs_in_spec.rb
+++ b/spec/system/authentication/user_logs_in_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 describe 'Usuário de transportadora se autentica' do
-  it 'com sucesso' do
-    express = create :express
-    create :user, email: 'usuario@express.com.br', password: 'password'
+  let!(:express) { create :express }
+  let!(:user) { create :user, email: 'usuario@express.com.br', password: 'password' }
 
+  it 'com sucesso' do
     visit root_path
     click_on 'Entrar (usuário)'
     fill_in 'E-mail', with: 'usuario@express.com.br'
@@ -19,23 +19,11 @@ describe 'Usuário de transportadora se autentica' do
     expect(page).to have_button 'Sair'
     expect(page).to have_link 'Express'
     expect(page).not_to have_link 'Transportadoras'
-  end
-
-  it 'e não vê mais links de autenticação' do
-    create :express
-    user = create :user
-
-    login_as user, scope: :user
-    visit root_path
-
     expect(page).not_to have_link 'Entrar (administrador)'
     expect(page).not_to have_link 'Entrar (usuário)'
   end
 
   it 'e faz logout' do
-    create :express
-    user = create :user
-
     login_as user, scope: :user
     visit root_path
     click_on 'Sair'

--- a/spec/system/authentication/visitor_signs_up_spec.rb
+++ b/spec/system/authentication/visitor_signs_up_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 describe 'Visitante cria uma conta' do
-  it 'com sucesso' do
-    express = create :express, email_domain: 'express.com.br'
+  let!(:express) { create :express, email_domain: 'express.com.br' }
 
+  it 'com sucesso' do
     visit new_user_session_path
     click_on 'Inscrever-se'
     fill_in 'E-mail', with: 'usuario@express.com.br'
@@ -20,8 +20,6 @@ describe 'Visitante cria uma conta' do
   end
 
   it 'com e-mail inválido' do
-    create :express, email_domain: 'express.com.br'
-
     visit new_user_session_path
     click_on 'Inscrever-se'
     fill_in 'E-mail', with: 'usuario@email.com'

--- a/spec/system/budget_searches/admin_budgets_order_spec.rb
+++ b/spec/system/budget_searches/admin_budgets_order_spec.rb
@@ -133,7 +133,7 @@ describe 'Administrador consulta preço de pedido' do
     fill_in 'Altura', with: '0'
     fill_in 'Largura', with: '0'
     fill_in 'Profundidade', with: '-1'
-    fill_in 'Peso', with: 'Z'
+    fill_in 'Peso', with: '0'
     fill_in 'Distância', with: '0'
     click_on 'Consultar'
 

--- a/spec/system/budget_searches/admin_budgets_order_spec.rb
+++ b/spec/system/budget_searches/admin_budgets_order_spec.rb
@@ -2,25 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Administrador consulta preço de pedido' do
-  it 'a partir do menu de navegação' do
-    admin = create :admin
-
-    login_as admin, scope: :admin
-    visit root_path
-    find('nav').click_on 'Consultar preços'
-
-    expect(page).to have_current_path new_budget_search_path
-    expect(page).to have_content 'Consulta de preços de transporte'
-    expect(page).to have_content 'Dimensões do item (em centímetros):'
-    expect(page).to have_field 'Altura'
-    expect(page).to have_field 'Largura'
-    expect(page).to have_field 'Profundidade'
-    expect(page).to have_field 'Peso do item (em quilogramas)'
-    expect(page).to have_field 'Distância a percorrer (em quilômetros)'
-    expect(page).to have_button 'Consultar'
-  end
-
+describe 'Administrador consulta preço de pedido,' do
   it 'sem se autenticar' do
     visit new_budget_search_path
 
@@ -28,120 +10,131 @@ describe 'Administrador consulta preço de pedido' do
     expect(page).to have_content 'Para continuar, faça login ou registre-se.'
   end
 
-  it 'com sucesso' do
-    admin = create :admin, email: 'admin@sistemadefrete.com.br'
-    express = create :express, brand_name: 'Express'
-    create :time_distance_range, shipping_company: express, min_distance: 0, max_distance: 100, delivery_time: 2
-    create :time_distance_range, shipping_company: express, min_distance: 101, max_distance: 200, delivery_time: 3
-    create :price_distance_range, shipping_company: express, min_distance: 0, max_distance: 100, value: 500
-    express_volume_range1 = create :volume_range, shipping_company: express, min_volume: 0, max_volume: 50
-    create :weight_range, volume_range: express_volume_range1, min_weight: 1, max_weight: 20, value: 50
-    express_volume_range2 = create :volume_range, shipping_company: express, min_volume: 51, max_volume: 100
-    create :weight_range, volume_range: express_volume_range2, min_weight: 1, max_weight: 10, value: 75
-    create :weight_range, volume_range: express_volume_range2, min_weight: 11, max_weight: 20, value: 100
-    a_jato = create :a_jato, brand_name: 'A Jato'
-    create :time_distance_range, shipping_company: a_jato, min_distance: 0, max_distance: 100, delivery_time: 3
-    create :time_distance_range, shipping_company: a_jato, min_distance: 101, max_distance: 200, delivery_time: 4
-    create :price_distance_range, shipping_company: a_jato, min_distance: 0, max_distance: 100, value: 5_000
-    a_jato_volume_range = create :volume_range, shipping_company: a_jato, min_volume: 0, max_volume: 100
-    create :weight_range, volume_range: a_jato_volume_range, min_weight: 1, max_weight: 5, value: 50
+  context 'autenticado,' do
+    let(:admin) { create :admin, email: 'admin@sistemadefrete.com.br' }
 
-    login_as admin, scope: :admin
-    visit new_budget_search_path
-    fill_in 'Altura', with: 100
-    fill_in 'Largura', with: 100
-    fill_in 'Profundidade', with: 100
-    fill_in 'Peso do item (em quilogramas)', with: 5
-    fill_in 'Distância a percorrer (em quilômetros)', with: 20
-    click_on 'Consultar'
+    before { login_as admin, scope: :admin }
 
-    expect(page).to have_content 'Resultado da sua busca:'
-    expect(page).to have_content "Busca no. #{BudgetSearch.last.id} (#{I18n.l(Date.current)})"
-    expect(page).to have_content 'Realizada por: admin@sistemadefrete.com.br'
-    expect(page).to have_content 'Volume: 1 m³'
-    expect(page).to have_content 'Peso: 5 kg'
-    expect(page).to have_content 'Distância a percorrer: 20 km'
-    within('#table_header') do
-      expect(page).to have_content 'Transportadora'
-      expect(page).to have_content 'Valor'
-      expect(page).to have_content 'Prazo'
+    it 'a partir do menu de navegação' do
+      visit root_path
+      find('nav').click_on 'Consultar preços'
+
+      expect(page).to have_current_path new_budget_search_path
+      expect(page).to have_content 'Consulta de preços de transporte'
+      expect(page).to have_content 'Dimensões do item (em centímetros):'
+      expect(page).to have_field 'Altura'
+      expect(page).to have_field 'Largura'
+      expect(page).to have_field 'Profundidade'
+      expect(page).to have_field 'Peso do item (em quilogramas)'
+      expect(page).to have_field 'Distância a percorrer (em quilômetros)'
+      expect(page).to have_button 'Consultar'
     end
-    within('#express') do
-      expect(page).to have_content 'Express'
-      expect(page).to have_content 'R$ 10,00'
-      expect(page).to have_content '2 dias'
+
+    it 'com sucesso' do
+      express = create :express, brand_name: 'Express'
+      create :time_distance_range, shipping_company: express, min_distance: 0, max_distance: 100, delivery_time: 2
+      create :time_distance_range, shipping_company: express, min_distance: 101, max_distance: 200, delivery_time: 3
+      create :price_distance_range, shipping_company: express, min_distance: 0, max_distance: 100, value: 500
+      express_volume_range1 = create :volume_range, shipping_company: express, min_volume: 0, max_volume: 50
+      create :weight_range, volume_range: express_volume_range1, min_weight: 1, max_weight: 20, value: 50
+      express_volume_range2 = create :volume_range, shipping_company: express, min_volume: 51, max_volume: 100
+      create :weight_range, volume_range: express_volume_range2, min_weight: 1, max_weight: 10, value: 75
+      create :weight_range, volume_range: express_volume_range2, min_weight: 11, max_weight: 20, value: 100
+      a_jato = create :a_jato, brand_name: 'A Jato'
+      create :time_distance_range, shipping_company: a_jato, min_distance: 0, max_distance: 100, delivery_time: 3
+      create :time_distance_range, shipping_company: a_jato, min_distance: 101, max_distance: 200, delivery_time: 4
+      create :price_distance_range, shipping_company: a_jato, min_distance: 0, max_distance: 100, value: 5_000
+      a_jato_volume_range = create :volume_range, shipping_company: a_jato, min_volume: 0, max_volume: 100
+      create :weight_range, volume_range: a_jato_volume_range, min_weight: 1, max_weight: 5, value: 50
+
+      visit new_budget_search_path
+      fill_in 'Altura', with: 100
+      fill_in 'Largura', with: 100
+      fill_in 'Profundidade', with: 100
+      fill_in 'Peso do item (em quilogramas)', with: 5
+      fill_in 'Distância a percorrer (em quilômetros)', with: 20
+      click_on 'Consultar'
+
+      expect(page).to have_content 'Resultado da sua busca:'
+      expect(page).to have_content "Busca no. #{BudgetSearch.last.id} (#{I18n.l(Date.current)})"
+      expect(page).to have_content 'Realizada por: admin@sistemadefrete.com.br'
+      expect(page).to have_content 'Volume: 1 m³'
+      expect(page).to have_content 'Peso: 5 kg'
+      expect(page).to have_content 'Distância a percorrer: 20 km'
+      within('#table_header') do
+        expect(page).to have_content 'Transportadora'
+        expect(page).to have_content 'Valor'
+        expect(page).to have_content 'Prazo'
+      end
+      within('#express') do
+        expect(page).to have_content 'Express'
+        expect(page).to have_content 'R$ 10,00'
+        expect(page).to have_content '2 dias'
+      end
+      within('#a_jato') do
+        expect(page).to have_content 'A Jato'
+        expect(page).to have_content 'R$ 50,00'
+        expect(page).to have_content '3 dias'
+      end
     end
-    within('#a_jato') do
-      expect(page).to have_content 'A Jato'
-      expect(page).to have_content 'R$ 50,00'
-      expect(page).to have_content '3 dias'
+
+    it 'e não há transportadoras para atendê-lo' do
+      express = create :express, brand_name: 'Express'
+      create :time_distance_range, shipping_company: express, min_distance: 0, max_distance: 100, delivery_time: 2
+      express_volume_range1 = create :volume_range, shipping_company: express, min_volume: 0, max_volume: 50
+      create :weight_range, volume_range: express_volume_range1, min_weight: 21, max_weight: 40, value: 50
+      express_volume_range2 = create :volume_range, shipping_company: express, min_volume: 51, max_volume: 100
+      create :weight_range, volume_range: express_volume_range2, min_weight: 0, max_weight: 20, value: 75
+      a_jato = create :a_jato, brand_name: 'A Jato'
+      create :time_distance_range, shipping_company: a_jato, min_distance: 101, max_distance: 200, delivery_time: 3
+      a_jato_volume_range = create :volume_range, shipping_company: a_jato, min_volume: 0, max_volume: 50
+      create :weight_range, volume_range: a_jato_volume_range, min_weight: 0, max_weight: 20, value: 50
+
+      visit new_budget_search_path
+      fill_in 'Altura', with: 100
+      fill_in 'Largura', with: 100
+      fill_in 'Profundidade', with: 100
+      fill_in 'Peso do item (em quilogramas)', with: 5
+      fill_in 'Distância a percorrer (em quilômetros)', with: 20
+      click_on 'Consultar'
+
+      expect(page).to have_content 'Resultado da sua busca:'
+      expect(page).to have_content "Busca no. 1 (#{I18n.l(Date.current)})"
+      expect(page).to have_content "Realizada por: #{admin.email}"
+      expect(page).to have_content 'Volume: 1 m³'
+      expect(page).to have_content 'Peso: 5 kg'
+      expect(page).to have_content 'Distância a percorrer: 20 km'
+      expect(page).to have_content 'Não foram encontradas transportadoras para esse pedido.'
     end
-  end
 
-  it 'e não há transportadoras para atendê-lo' do
-    admin = create :admin
-    express = create :express, brand_name: 'Express'
-    TimeDistanceRange.create!(shipping_company: express, min_distance: 0, max_distance: 100, delivery_time: 2)
-    first_express_volume_range = VolumeRange.create!(shipping_company: express, min_volume: 0, max_volume: 50)
-    WeightRange.create!(volume_range: first_express_volume_range, min_weight: 21, max_weight: 40, value: 50)
-    second_express_volume_range = VolumeRange.create!(shipping_company: express, min_volume: 51, max_volume: 100)
-    WeightRange.create!(volume_range: second_express_volume_range, min_weight: 0, max_weight: 20, value: 75)
-    a_jato = create :a_jato, brand_name: 'A Jato'
-    TimeDistanceRange.create!(shipping_company: a_jato, min_distance: 101, max_distance: 200, delivery_time: 3)
-    a_jato_volume_range = VolumeRange.create!(shipping_company: a_jato, min_volume: 0, max_volume: 50)
-    WeightRange.create!(volume_range: a_jato_volume_range, min_weight: 0, max_weight: 20, value: 50)
+    it 'com dados incompletos' do
+      visit new_budget_search_path
+      fill_in 'Altura', with: '100'
+      click_on 'Consultar'
 
-    login_as admin, scope: :admin
-    visit new_budget_search_path
-    fill_in 'Altura', with: 100
-    fill_in 'Largura', with: 100
-    fill_in 'Profundidade', with: 100
-    fill_in 'Peso do item (em quilogramas)', with: 5
-    fill_in 'Distância a percorrer (em quilômetros)', with: 20
-    click_on 'Consultar'
+      expect(page).to have_content 'Sua busca não pôde ser realizada.'
+      expect(page).to have_field 'Altura', with: '100'
+      expect(page).to have_content 'Largura não pode ficar em branco'
+      expect(page).to have_content 'Profundidade não pode ficar em branco'
+      expect(page).to have_content 'Peso não pode ficar em branco'
+      expect(page).to have_content 'Distância não pode ficar em branco'
+    end
 
-    expect(page).to have_content 'Resultado da sua busca:'
-    expect(page).to have_content "Busca no. 1 (#{I18n.l(Date.current)})"
-    expect(page).to have_content "Realizada por: #{admin.email}"
-    expect(page).to have_content 'Volume: 1 m³'
-    expect(page).to have_content 'Peso: 5 kg'
-    expect(page).to have_content 'Distância a percorrer: 20 km'
-    expect(page).to have_content 'Não foram encontradas transportadoras para esse pedido.'
-  end
+    it 'com dados inválidos' do
+      visit new_budget_search_path
+      fill_in 'Altura', with: '0'
+      fill_in 'Largura', with: '0'
+      fill_in 'Profundidade', with: '-1'
+      fill_in 'Peso', with: '0'
+      fill_in 'Distância', with: '0'
+      click_on 'Consultar'
 
-  it 'com dados incompletos' do
-    admin = create :admin
-
-    login_as admin, scope: :admin
-    visit new_budget_search_path
-    fill_in 'Altura', with: '100'
-    click_on 'Consultar'
-
-    expect(page).to have_content 'Sua busca não pôde ser realizada.'
-    expect(page).to have_field 'Altura', with: '100'
-    expect(page).to have_content 'Largura não pode ficar em branco'
-    expect(page).to have_content 'Profundidade não pode ficar em branco'
-    expect(page).to have_content 'Peso não pode ficar em branco'
-    expect(page).to have_content 'Distância não pode ficar em branco'
-  end
-
-  it 'com dados inválidos' do
-    admin = create :admin
-
-    login_as admin, scope: :admin
-    visit new_budget_search_path
-    fill_in 'Altura', with: '0'
-    fill_in 'Largura', with: '0'
-    fill_in 'Profundidade', with: '-1'
-    fill_in 'Peso', with: '0'
-    fill_in 'Distância', with: '0'
-    click_on 'Consultar'
-
-    expect(page).to have_content 'Sua busca não pôde ser realizada.'
-    expect(page).to have_content 'Altura deve ser maior que 0'
-    expect(page).to have_content 'Largura deve ser maior que 0'
-    expect(page).to have_content 'Profundidade deve ser maior que 0'
-    expect(page).to have_content 'Peso deve ser maior que 0'
-    expect(page).to have_content 'Distância deve ser maior que 0'
+      expect(page).to have_content 'Sua busca não pôde ser realizada.'
+      expect(page).to have_content 'Altura deve ser maior que 0'
+      expect(page).to have_content 'Largura deve ser maior que 0'
+      expect(page).to have_content 'Profundidade deve ser maior que 0'
+      expect(page).to have_content 'Peso deve ser maior que 0'
+      expect(page).to have_content 'Distância deve ser maior que 0'
+    end
   end
 end

--- a/spec/system/budget_searches/admin_views_budget_searches_spec.rb
+++ b/spec/system/budget_searches/admin_views_budget_searches_spec.rb
@@ -3,13 +3,15 @@
 require 'rails_helper'
 
 describe 'Administrador vê as buscas de preço realizadas' do
+  let(:admin) { create :admin, email: 'admin@sistemadefrete.com.br' }
+
+  before { login_as admin, scope: :admin }
+
   it 'na página inicial' do
-    admin = create :admin, email: 'admin@sistemadefrete.com.br'
     other_admin = create :admin, email: 'other@sistemadefrete.com.br'
     search1 = create :budget_search, admin: admin
     search2 = create :budget_search, admin: other_admin
 
-    login_as admin, scope: :admin
     visit root_path
 
     expect(page).not_to have_content 'Não há buscas de orçamento registradas.'
@@ -34,19 +36,14 @@ describe 'Administrador vê as buscas de preço realizadas' do
   end
 
   it 'e não há nenhuma' do
-    admin = create :admin
-
-    login_as admin, scope: :admin
     visit root_path
 
     expect(page).to have_content 'Não há buscas de orçamento registradas.'
   end
 
   it 'e acessa os detalhes de uma' do
-    admin = create :admin
     search = create :budget_search, admin: admin
 
-    login_as admin, scope: :admin
     visit root_path
     click_on search.id.to_s
 

--- a/spec/system/delivery_times/user_registers_delivery_time_spec.rb
+++ b/spec/system/delivery_times/user_registers_delivery_time_spec.rb
@@ -2,75 +2,66 @@
 
 require 'rails_helper'
 
-describe 'Usuário registra um novo intervalo de distância' do
-  it 'sem se autenticar' do
-    express = create :express
+describe 'Usuário registra um novo intervalo de distância,' do
+  let!(:express) { create :express }
 
+  it 'sem se autenticar' do
     visit new_shipping_company_time_distance_range_path(express)
 
     expect(page).to have_current_path new_user_session_path
     expect(page).to have_content 'Para continuar, faça login ou registre-se.'
   end
 
-  it 'com sucesso' do
-    express = create :express
-    user = create :user
+  context 'autenticado,' do
+    let(:user) { create :user }
 
-    login_as user, scope: :user
-    visit shipping_company_path(express)
-    find('section#delivery_times').click_on 'Cadastrar intervalo de distância'
-    fill_in 'Distância mínima', with: '0'
-    fill_in 'Distância máxima', with: '100'
-    fill_in 'Prazo', with: '2'
-    click_on 'Criar Intervalo de distância'
+    before { login_as user, scope: :user }
 
-    expect(page).to have_content 'Intervalo cadastrado com sucesso.'
-    within_table('delivery_times_table') do
-      expect(page).to have_content '0-100 km'
-      expect(page).to have_content '2 dias'
+    it 'com sucesso' do
+      visit shipping_company_path(express)
+      find('section#delivery_times').click_on 'Cadastrar intervalo de distância'
+      fill_in 'Distância mínima', with: '0'
+      fill_in 'Distância máxima', with: '100'
+      fill_in 'Prazo', with: '2'
+      click_on 'Criar Intervalo de distância'
+
+      expect(page).to have_content 'Intervalo cadastrado com sucesso.'
+      within_table('delivery_times_table') do
+        expect(page).to have_content '0-100 km'
+        expect(page).to have_content '2 dias'
+      end
     end
-  end
 
-  it 'com dados incompletos' do
-    express = create :express
-    user = create :user
+    it 'com dados incompletos' do
+      visit new_shipping_company_time_distance_range_path(express)
+      fill_in 'Distância mínima', with: '0'
+      click_on 'Criar Intervalo de distância'
 
-    login_as user, scope: :user
-    visit new_shipping_company_time_distance_range_path(express)
-    fill_in 'Distância mínima', with: '0'
-    click_on 'Criar Intervalo de distância'
+      expect(page).to have_content 'Intervalo não cadastrado.'
+      expect(page).to have_field 'Distância mínima', with: '0'
+      expect(page).to have_content 'Distância máxima não pode ficar em branco'
+      expect(page).to have_content 'Prazo não pode ficar em branco'
+    end
 
-    expect(page).to have_content 'Intervalo não cadastrado.'
-    expect(page).to have_field 'Distância mínima', with: '0'
-    expect(page).to have_content 'Distância máxima não pode ficar em branco'
-    expect(page).to have_content 'Prazo não pode ficar em branco'
-  end
+    it 'com dados inválidos' do
+      create :time_distance_range, shipping_company: express, min_distance: 0
 
-  it 'com dados inválidos' do
-    express = create :express
-    user = create :user
-    create :time_distance_range, shipping_company: express, min_distance: 0
+      visit new_shipping_company_time_distance_range_path(express)
+      fill_in 'Distância mínima', with: '0'
+      fill_in 'Distância máxima', with: '0'
+      click_on 'Criar Intervalo de distância'
 
-    login_as user, scope: :user
-    visit new_shipping_company_time_distance_range_path(express)
-    fill_in 'Distância mínima', with: '0'
-    fill_in 'Distância máxima', with: '0'
-    click_on 'Criar Intervalo de distância'
+      expect(page).to have_content 'Distância mínima não pode estar contida em intervalos já registrados'
+      expect(page).to have_content 'Distância máxima deve ser maior que 0'
+    end
 
-    expect(page).to have_content 'Distância mínima não pode estar contida em intervalos já registrados'
-    expect(page).to have_content 'Distância máxima deve ser maior que 0'
-  end
+    it 'com distância mínima >= distância máxima' do
+      visit new_shipping_company_time_distance_range_path(express)
+      fill_in 'Distância mínima', with: '10'
+      fill_in 'Distância máxima', with: '5'
+      click_on 'Criar Intervalo de distância'
 
-  it 'com distância mínima >= distância máxima' do
-    express = create :express
-    user = create :user
-
-    login_as user, scope: :user
-    visit new_shipping_company_time_distance_range_path(express)
-    fill_in 'Distância mínima', with: '10'
-    fill_in 'Distância máxima', with: '5'
-    click_on 'Criar Intervalo de distância'
-
-    expect(page).to have_content 'Distância mínima deve ser menor que distância máxima'
+      expect(page).to have_content 'Distância mínima deve ser menor que distância máxima'
+    end
   end
 end

--- a/spec/system/delivery_times/user_views_company_delivery_times_spec.rb
+++ b/spec/system/delivery_times/user_views_company_delivery_times_spec.rb
@@ -3,11 +3,12 @@
 require 'rails_helper'
 
 describe 'Usuário vê tabela de prazos da transportadora' do
-  it 'e não há intervalos de distância cadastrados' do
-    express = create :express
-    user = create :user
+  let!(:express) { create :express }
+  let(:user) { create :user }
 
-    login_as user, scope: :user
+  before { login_as user, scope: :user }
+
+  it 'e não há intervalos de distância cadastrados' do
     visit shipping_company_path(express)
 
     expect(page).to have_content 'Tabela de prazos'
@@ -18,12 +19,15 @@ describe 'Usuário vê tabela de prazos da transportadora' do
   end
 
   it 'e vê intervalos de distância' do
-    express = create :express
-    user = create :user
-    create :time_distance_range, shipping_company: express, min_distance: 0, max_distance: 100, delivery_time: 2
-    create :time_distance_range, shipping_company: express, min_distance: 101, max_distance: 200, delivery_time: 3
+    create :time_distance_range, shipping_company: express,
+                                 min_distance: 0,
+                                 max_distance: 100,
+                                 delivery_time: 2
+    create :time_distance_range, shipping_company: express,
+                                 min_distance: 101,
+                                 max_distance: 200,
+                                 delivery_time: 3
 
-    login_as user, scope: :user
     visit shipping_company_path(express)
 
     within('section#delivery_times') do

--- a/spec/system/min_prices/user_registers_min_price_spec.rb
+++ b/spec/system/min_prices/user_registers_min_price_spec.rb
@@ -2,75 +2,65 @@
 
 require 'rails_helper'
 
-describe 'Usuário registra um novo intervalo de distância' do
-  it 'sem se autenticar' do
-    express = create :express
+describe 'Usuário registra um novo intervalo de distância,' do
+  let!(:express) { create :express }
+  let(:user) { create :user }
 
+  it 'sem se autenticar' do
     visit new_shipping_company_price_distance_range_path(express)
 
     expect(page).to have_current_path new_user_session_path
     expect(page).to have_content 'Para continuar, faça login ou registre-se.'
   end
 
-  it 'com sucesso' do
-    express = create :express
-    user = create :user
+  context 'autenticado,' do
+    before { login_as user, scope: :user }
 
-    login_as user, scope: :user
-    visit shipping_company_path(express)
-    find('section#prices').click_on 'Cadastrar intervalo de distância'
-    fill_in 'Distância mínima', with: '0'
-    fill_in 'Distância máxima', with: '100'
-    fill_in 'Valor', with: '5000'
-    click_on 'Criar Intervalo de distância'
+    it 'com sucesso' do
+      visit shipping_company_path(express)
+      find('section#prices').click_on 'Cadastrar intervalo de distância'
+      fill_in 'Distância mínima', with: '0'
+      fill_in 'Distância máxima', with: '100'
+      fill_in 'Valor', with: '5000'
+      click_on 'Criar Intervalo de distância'
 
-    expect(page).to have_content 'Intervalo cadastrado com sucesso.'
-    within_table('min_prices_table') do
-      expect(page).to have_content '0-100 km'
-      expect(page).to have_content 'R$ 50,00'
+      expect(page).to have_content 'Intervalo cadastrado com sucesso.'
+      within_table('min_prices_table') do
+        expect(page).to have_content '0-100 km'
+        expect(page).to have_content 'R$ 50,00'
+      end
     end
-  end
 
-  it 'com dados incompletos' do
-    express = create :express
-    user = create :user
+    it 'com dados incompletos' do
+      visit new_shipping_company_price_distance_range_path(express)
+      fill_in 'Distância mínima', with: '0'
+      click_on 'Criar Intervalo de distância'
 
-    login_as user, scope: :user
-    visit new_shipping_company_price_distance_range_path(express)
-    fill_in 'Distância mínima', with: '0'
-    click_on 'Criar Intervalo de distância'
+      expect(page).to have_content 'Intervalo não cadastrado.'
+      expect(page).to have_field 'Distância mínima', with: '0'
+      expect(page).to have_content 'Distância máxima não pode ficar em branco'
+      expect(page).to have_content 'Valor não pode ficar em branco'
+    end
 
-    expect(page).to have_content 'Intervalo não cadastrado.'
-    expect(page).to have_field 'Distância mínima', with: '0'
-    expect(page).to have_content 'Distância máxima não pode ficar em branco'
-    expect(page).to have_content 'Valor não pode ficar em branco'
-  end
+    it 'com dados inválidos' do
+      create :price_distance_range, shipping_company: express, min_distance: 0
 
-  it 'com dados inválidos' do
-    express = create :express
-    user = create :user
-    create :price_distance_range, shipping_company: express, min_distance: 0
+      visit new_shipping_company_price_distance_range_path(express)
+      fill_in 'Distância mínima', with: '0'
+      fill_in 'Distância máxima', with: '0'
+      click_on 'Criar Intervalo de distância'
 
-    login_as user, scope: :user
-    visit new_shipping_company_price_distance_range_path(express)
-    fill_in 'Distância mínima', with: '0'
-    fill_in 'Distância máxima', with: '0'
-    click_on 'Criar Intervalo de distância'
+      expect(page).to have_content 'Distância mínima não pode estar contida em intervalos já registrados'
+      expect(page).to have_content 'Distância máxima deve ser maior que 0'
+    end
 
-    expect(page).to have_content 'Distância mínima não pode estar contida em intervalos já registrados'
-    expect(page).to have_content 'Distância máxima deve ser maior que 0'
-  end
+    it 'com distância mínima >= distância máxima' do
+      visit new_shipping_company_price_distance_range_path(express)
+      fill_in 'Distância mínima', with: '10'
+      fill_in 'Distância máxima', with: '5'
+      click_on 'Criar Intervalo de distância'
 
-  it 'com distância mínima >= distância máxima' do
-    express = create :express
-    user = create :user
-
-    login_as user, scope: :user
-    visit new_shipping_company_price_distance_range_path(express)
-    fill_in 'Distância mínima', with: '10'
-    fill_in 'Distância máxima', with: '5'
-    click_on 'Criar Intervalo de distância'
-
-    expect(page).to have_content 'Distância mínima deve ser menor que distância máxima'
+      expect(page).to have_content 'Distância mínima deve ser menor que distância máxima'
+    end
   end
 end

--- a/spec/system/min_prices/user_views_company_min_prices_spec.rb
+++ b/spec/system/min_prices/user_views_company_min_prices_spec.rb
@@ -3,11 +3,12 @@
 require 'rails_helper'
 
 describe 'Usuário vê tabela de preços mínimos da transportadora' do
-  it 'e não há intervalos de distância cadastrados' do
-    express = create :express
-    user = create :user
+  let!(:express) { create :express }
+  let(:user) { create :user }
 
-    login_as user, scope: :user
+  before { login_as user, scope: :user }
+
+  it 'e não há intervalos de distância cadastrados' do
     visit shipping_company_path(express)
 
     within('section#prices') do
@@ -18,17 +19,12 @@ describe 'Usuário vê tabela de preços mínimos da transportadora' do
   end
 
   it 'e vê intervalos de distância' do
-    express = create :express
-    user = create :user
     create :price_distance_range, shipping_company: express, min_distance: 0, max_distance: 100, value: 5_000
     create :price_distance_range, shipping_company: express, min_distance: 101, max_distance: 200, value: 10_000
 
-    login_as user, scope: :user
     visit shipping_company_path(express)
 
-    within('section#prices') do
-      expect(page).not_to have_content 'Não existem intervalos de distância cadastrados.'
-    end
+    within('section#prices') { expect(page).not_to have_content 'Não existem intervalos de distância cadastrados.' }
     within_table('min_prices_table') do
       within('#table_header') do
         expect(page).to have_content 'Distância'

--- a/spec/system/orders/admin_registers_order_spec.rb
+++ b/spec/system/orders/admin_registers_order_spec.rb
@@ -3,8 +3,18 @@
 require 'rails_helper'
 
 describe 'Administrador cria um novo pedido' do
+  let(:admin) { create :admin }
+
+  before { login_as admin, scope: :admin }
+
+  it 'sem realizar busca antes' do
+    visit new_order_path
+
+    expect(page).to have_current_path root_path
+    expect(page).to have_content 'Crie um pedido a partir de uma consulta de preços.'
+  end
+
   it 'a partir de uma busca de preços' do
-    admin = create :admin
     express = create :express, corporate_name: 'Express Transportes Ltda.'
     create :time_distance_range, shipping_company: express, min_distance: 0, max_distance: 100, delivery_time: 2
     create :price_distance_range, shipping_company: express, min_distance: 0, max_distance: 100, value: 500
@@ -17,7 +27,6 @@ describe 'Administrador cria um novo pedido' do
     create :weight_range, volume_range: a_jato_volume_range
     search = create :budget_search, height: 100, width: 100, depth: 100, weight: 5, distance: 50, admin: admin
 
-    login_as admin, scope: :admin
     visit budget_search_path(search)
     find('#express').click_on 'Enviar pedido'
 
@@ -44,18 +53,7 @@ describe 'Administrador cria um novo pedido' do
     expect(page).to have_button 'Enviar pedido'
   end
 
-  it 'sem realizar busca' do
-    admin = create :admin
-
-    login_as admin, scope: :admin
-    visit new_order_path
-
-    expect(page).to have_current_path root_path
-    expect(page).to have_content 'Crie um pedido a partir de uma consulta de preços.'
-  end
-
   it 'com sucesso' do
-    admin = create :admin
     express = create :express
     create :time_distance_range, shipping_company: express, min_distance: 0, max_distance: 100, delivery_time: 2
     create :price_distance_range, shipping_company: express, min_distance: 0, max_distance: 100, value: 500
@@ -64,7 +62,6 @@ describe 'Administrador cria um novo pedido' do
     search = create :budget_search, height: 100, width: 100, depth: 100, weight: 5, distance: 50, admin: admin
     allow(SecureRandom).to receive(:alphanumeric).and_return('ABCDE12345ABCDE')
 
-    login_as admin, scope: :admin
     visit budget_search_path(search)
     find('#express').click_on 'Enviar pedido'
     within('#pickup_address') do
@@ -98,7 +95,6 @@ describe 'Administrador cria um novo pedido' do
   end
 
   it 'com dados incompletos' do
-    admin = create :admin
     express = create :express
     create :time_distance_range, shipping_company: express
     create :price_distance_range, shipping_company: express
@@ -106,7 +102,6 @@ describe 'Administrador cria um novo pedido' do
     create :weight_range, volume_range: volume_range
     search = create :budget_search, admin: admin
 
-    login_as admin, scope: :admin
     visit budget_search_path(search)
     find('#express').click_on 'Enviar pedido'
     click_on 'Enviar pedido'
@@ -120,7 +115,7 @@ describe 'Administrador cria um novo pedido' do
       expect(page).to have_content 'Endereço não pode ficar em branco'
       expect(page).to have_content 'Cidade não pode ficar em branco'
     end
-    expect(page).to have_content 'Nome(a) do destinatário(a) não pode ficar em branco'
+    expect(page).to have_content 'Nome(a) do(a) destinatário(a) não pode ficar em branco'
     expect(page).to have_content 'Código do produto não pode ficar em branco'
   end
 end

--- a/spec/system/orders/admin_views_company_orders_spec.rb
+++ b/spec/system/orders/admin_views_company_orders_spec.rb
@@ -3,11 +3,13 @@
 require 'rails_helper'
 
 describe 'Administrador vê pedidos de uma transportadora' do
-  it 'e não há nenhum' do
-    express = create :express
-    admin = create :admin
+  let(:admin) { create :admin }
+  let(:express) { create :express }
+  let(:vehicle) { create :vehicle, shipping_company: express }
 
-    login_as admin, scope: :admin
+  before { login_as admin, scope: :admin }
+
+  it 'e não há nenhum' do
     visit shipping_company_path(express)
     click_on 'Pedidos'
 
@@ -17,16 +19,12 @@ describe 'Administrador vê pedidos de uma transportadora' do
   end
 
   it 'com sucesso' do
-    express = create :express
-    admin = create :admin
-    vehicle = create :vehicle, shipping_company: express
     allow(SecureRandom).to receive(:alphanumeric).and_return('ABCDE12345ABCDE')
     create :order, shipping_company: express, estimated_delivery_time: 2, value: 2_500
     allow(SecureRandom).to receive(:alphanumeric).and_return('12345ABCDE12345')
     create :order, shipping_company: express, estimated_delivery_time: 4, value: 5_000, status: :accepted,
                    vehicle: vehicle
 
-    login_as admin, scope: :admin
     visit shipping_company_path(express)
     click_on 'Pedidos'
 

--- a/spec/system/orders/user_updates_order_route_spec.rb
+++ b/spec/system/orders/user_updates_order_route_spec.rb
@@ -3,14 +3,16 @@
 require 'rails_helper'
 
 describe 'Usuário atualiza rota do pedido' do
+  let!(:express) { create :express }
+  let(:user) { create :user }
+  let(:vehicle) { create :vehicle, shipping_company: express }
+
+  before { login_as user, scope: :user }
+
   it 'com sucesso' do
-    express = create :express, email_domain: 'express.com.br'
-    user = create :user, email: 'usuario@express.com.br'
-    vehicle = create :vehicle, shipping_company: express
     order = create :order, shipping_company: express, status: :accepted, vehicle: vehicle
     current_time = Time.current
 
-    login_as user, scope: :user
     visit shipping_company_path(express)
     click_on 'Pedidos'
     click_on order.code
@@ -38,12 +40,8 @@ describe 'Usuário atualiza rota do pedido' do
   end
 
   it 'com dados incompletos' do
-    express = create :express, email_domain: 'express.com.br'
-    user = create :user, email: 'usuario@express.com.br'
-    vehicle = create :vehicle, shipping_company: express
     order = create :order, shipping_company: express, status: :accepted, vehicle: vehicle
 
-    login_as user, scope: :user
     visit order_path(order)
     click_on 'Atualizar rota de entrega'
 
@@ -54,12 +52,8 @@ describe 'Usuário atualiza rota do pedido' do
   end
 
   it 'com dados inválidos' do
-    express = create :express
-    user = create :user
-    vehicle = create :vehicle, shipping_company: express
     order = create :order, shipping_company: express, status: :accepted, vehicle: vehicle
 
-    login_as user, scope: :user
     visit order_path(order)
     fill_in 'Latitude', with: '-90.1'
     fill_in 'Longitude', with: '180.1'
@@ -73,14 +67,10 @@ describe 'Usuário atualiza rota do pedido' do
   end
 
   it 'com data e hora anteriores à última atualização' do
-    express = create :express, email_domain: 'express.com.br'
-    user = create :user, email: 'usuario@express.com.br'
-    vehicle = create :vehicle, shipping_company: express
     order = create :order, shipping_company: express, status: :accepted, vehicle: vehicle
     current_time = Time.current
     create :route_update, order: order, date_and_time: current_time
 
-    login_as user, scope: :user
     visit order_path(order)
     fill_in 'Data e hora', with: 1.second.before(current_time)
     click_on 'Atualizar rota de entrega'

--- a/spec/system/orders/user_updates_order_route_spec.rb
+++ b/spec/system/orders/user_updates_order_route_spec.rb
@@ -67,9 +67,9 @@ describe 'Usuário atualiza rota do pedido' do
     click_on 'Atualizar rota de entrega'
 
     expect(page).to have_content 'Rota de entrega não atualizada.'
-    expect(page).to have_content 'Latitude deve estar entre -90 e 90'
-    expect(page).to have_content 'Longitude deve estar entre -180 e 180'
-    expect(page).to have_content 'Data e hora não podem estar no futuro'
+    expect(page).to have_content 'Latitude deve ser maior ou igual a -90'
+    expect(page).to have_content 'Longitude deve ser menor ou igual a 180'
+    expect(page).to have_content "Data e hora deve ser menor ou igual a #{Time.zone.now}"
   end
 
   it 'com data e hora anteriores à última atualização' do

--- a/spec/system/orders/user_updates_order_route_spec.rb
+++ b/spec/system/orders/user_updates_order_route_spec.rb
@@ -10,7 +10,9 @@ describe 'Usuário atualiza rota do pedido' do
   before { login_as user, scope: :user }
 
   it 'com sucesso' do
-    order = create :order, shipping_company: express, status: :accepted, vehicle: vehicle
+    order = create :order, shipping_company: express,
+                           status: :accepted,
+                           vehicle: vehicle
     current_time = Time.current
 
     visit shipping_company_path(express)
@@ -40,7 +42,9 @@ describe 'Usuário atualiza rota do pedido' do
   end
 
   it 'com dados incompletos' do
-    order = create :order, shipping_company: express, status: :accepted, vehicle: vehicle
+    order = create :order, shipping_company: express,
+                           status: :accepted,
+                           vehicle: vehicle
 
     visit order_path(order)
     click_on 'Atualizar rota de entrega'
@@ -52,7 +56,9 @@ describe 'Usuário atualiza rota do pedido' do
   end
 
   it 'com dados inválidos' do
-    order = create :order, shipping_company: express, status: :accepted, vehicle: vehicle
+    order = create :order, shipping_company: express,
+                           status: :accepted,
+                           vehicle: vehicle
 
     visit order_path(order)
     fill_in 'Latitude', with: '-90.1'
@@ -67,9 +73,12 @@ describe 'Usuário atualiza rota do pedido' do
   end
 
   it 'com data e hora anteriores à última atualização' do
-    order = create :order, shipping_company: express, status: :accepted, vehicle: vehicle
+    order = create :order, shipping_company: express,
+                           status: :accepted,
+                           vehicle: vehicle
     current_time = Time.current
-    create :route_update, order: order, date_and_time: current_time
+    create :route_update, order: order,
+                          date_and_time: current_time
 
     visit order_path(order)
     fill_in 'Data e hora', with: 1.second.before(current_time)

--- a/spec/system/orders/user_updates_order_status_spec.rb
+++ b/spec/system/orders/user_updates_order_status_spec.rb
@@ -10,9 +10,12 @@ describe 'Usuário atualiza o status de um pedido' do
 
   context 'e aceita-o' do
     it 'com sucesso' do
-      create :vehicle, shipping_company: express, license_plate: 'BRA3R52'
-      create :vehicle, shipping_company: express, license_plate: 'ARG4523'
-      order = create :order, shipping_company: express, status: :pending
+      create :vehicle, shipping_company: express,
+                       license_plate: 'BRA3R52'
+      create :vehicle, shipping_company: express,
+                       license_plate: 'ARG4523'
+      order = create :order, shipping_company: express,
+                             status: :pending
 
       visit shipping_company_path(express)
       click_on 'Pedidos'
@@ -28,7 +31,8 @@ describe 'Usuário atualiza o status de um pedido' do
 
     it 'sem escolher veículo' do
       create :vehicle, shipping_company: express
-      order = create :order, shipping_company: express, status: :pending
+      order = create :order, shipping_company: express,
+                             status: :pending
 
       visit shipping_company_path(express)
       click_on 'Pedidos'
@@ -45,7 +49,8 @@ describe 'Usuário atualiza o status de um pedido' do
   end
 
   it 'e rejeita-o' do
-    order = create :order, shipping_company: express, status: :pending
+    order = create :order, shipping_company: express,
+                           status: :pending
 
     visit shipping_company_path(express)
     click_on 'Pedidos'
@@ -60,7 +65,9 @@ describe 'Usuário atualiza o status de um pedido' do
 
   it 'e finaliza-o' do
     vehicle = create :vehicle, shipping_company: express
-    order = create :order, shipping_company: express, status: :accepted, vehicle: vehicle
+    order = create :order, shipping_company: express,
+                           status: :accepted,
+                           vehicle: vehicle
 
     visit shipping_company_path(express)
     click_on 'Pedidos'

--- a/spec/system/orders/user_updates_order_status_spec.rb
+++ b/spec/system/orders/user_updates_order_status_spec.rb
@@ -3,15 +3,17 @@
 require 'rails_helper'
 
 describe 'Usuário atualiza o status de um pedido' do
+  let!(:express) { create :express }
+  let(:user) { create :user }
+
+  before { login_as user, scope: :user }
+
   context 'e aceita-o' do
     it 'com sucesso' do
-      express = create :express, email_domain: 'express.com.br'
-      user = create :user, email: 'usuario@express.com.br'
       create :vehicle, shipping_company: express, license_plate: 'BRA3R52'
       create :vehicle, shipping_company: express, license_plate: 'ARG4523'
       order = create :order, shipping_company: express, status: :pending
 
-      login_as user, scope: :user
       visit shipping_company_path(express)
       click_on 'Pedidos'
       click_on order.code
@@ -25,12 +27,9 @@ describe 'Usuário atualiza o status de um pedido' do
     end
 
     it 'sem escolher veículo' do
-      express = create :express, email_domain: 'express.com.br'
-      user = create :user, email: 'usuario@express.com.br'
       create :vehicle, shipping_company: express
       order = create :order, shipping_company: express, status: :pending
 
-      login_as user, scope: :user
       visit shipping_company_path(express)
       click_on 'Pedidos'
       click_on order.code
@@ -46,11 +45,8 @@ describe 'Usuário atualiza o status de um pedido' do
   end
 
   it 'e rejeita-o' do
-    express = create :express, email_domain: 'express.com.br'
-    user = create :user, email: 'usuario@express.com.br'
     order = create :order, shipping_company: express, status: :pending
 
-    login_as user, scope: :user
     visit shipping_company_path(express)
     click_on 'Pedidos'
     click_on order.code
@@ -63,12 +59,9 @@ describe 'Usuário atualiza o status de um pedido' do
   end
 
   it 'e finaliza-o' do
-    express = create :express, email_domain: 'express.com.br'
-    user = create :user, email: 'usuario@express.com.br'
     vehicle = create :vehicle, shipping_company: express
     order = create :order, shipping_company: express, status: :accepted, vehicle: vehicle
 
-    login_as user, scope: :user
     visit shipping_company_path(express)
     click_on 'Pedidos'
     click_on order.code

--- a/spec/system/orders/user_views_company_orders_spec.rb
+++ b/spec/system/orders/user_views_company_orders_spec.rb
@@ -10,54 +10,54 @@ describe 'Usuário vê pedidos da sua transportadora' do
     expect(page).to have_content 'Para continuar, faça login ou registre-se.'
   end
 
-  it 'e não há nenhum' do
-    express = create :express, email_domain: 'express.com.br'
-    user = create :user, email: 'user@express.com.br'
+  context 'autenticado' do
+    let!(:express) { create :express }
+    let(:user) { create :user }
 
-    login_as user, scope: :user
-    visit shipping_company_path(express)
-    click_on 'Pedidos'
+    before { login_as user, scope: :user }
 
-    expect(page).to have_content 'Pedidos de Express Transportes Ltda.'
-    expect(page).to have_content 'Esta transportadora não recebeu nenhum pedido.'
-    expect(page).to have_link 'Voltar'
-  end
+    it 'e não há nenhum' do
+      visit shipping_company_path(express)
+      click_on 'Pedidos'
 
-  it 'com sucesso' do
-    express = create :express, email_domain: 'express.com.br'
-    user = create :user, email: 'usuario@express.com.br'
-    vehicle = create :vehicle, shipping_company: express
-    allow(SecureRandom).to receive(:alphanumeric).and_return('ABCDE12345ABCDE')
-    create :order, shipping_company: express, estimated_delivery_time: 2, value: 2_500
-    allow(SecureRandom).to receive(:alphanumeric).and_return('12345ABCDE12345')
-    create :order, shipping_company: express, estimated_delivery_time: 4, value: 5_000, status: :accepted,
-                   vehicle: vehicle
+      expect(page).to have_content 'Pedidos de Express Transportes Ltda.'
+      expect(page).to have_content 'Esta transportadora não recebeu nenhum pedido.'
+      expect(page).to have_link 'Voltar'
+    end
 
-    login_as user, scope: :user
-    visit shipping_company_path(express)
-    click_on 'Pedidos'
+    it 'com sucesso' do
+      vehicle = create :vehicle, shipping_company: express
+      allow(SecureRandom).to receive(:alphanumeric).and_return('ABCDE12345ABCDE')
+      create :order, shipping_company: express, estimated_delivery_time: 2, value: 2_500
+      allow(SecureRandom).to receive(:alphanumeric).and_return('12345ABCDE12345')
+      create :order, shipping_company: express, estimated_delivery_time: 4, value: 5_000, status: :accepted,
+                     vehicle: vehicle
 
-    within_table('orders') do
-      within('#table_header') do
-        expect(page).to have_content 'Código'
-        expect(page).to have_content 'Data de criação'
-        expect(page).to have_content 'Tempo de entrega previsto'
-        expect(page).to have_content 'Valor'
-        expect(page).to have_content 'Status'
-      end
-      within('#ABCDE12345ABCDE') do
-        expect(page).to have_link 'ABCDE12345ABCDE'
-        expect(page).to have_content I18n.l(Date.current)
-        expect(page).to have_content '2 dias'
-        expect(page).to have_content 'R$ 25,00'
-        expect(page).to have_content 'Pendente'
-      end
-      within('#12345ABCDE12345') do
-        expect(page).to have_link '12345ABCDE12345'
-        expect(page).to have_content I18n.l(Date.current)
-        expect(page).to have_content '4 dias'
-        expect(page).to have_content 'R$ 50,00'
-        expect(page).to have_content 'Aceito'
+      visit shipping_company_path(express)
+      click_on 'Pedidos'
+
+      within_table('orders') do
+        within('#table_header') do
+          expect(page).to have_content 'Código'
+          expect(page).to have_content 'Data de criação'
+          expect(page).to have_content 'Tempo de entrega previsto'
+          expect(page).to have_content 'Valor'
+          expect(page).to have_content 'Status'
+        end
+        within('#ABCDE12345ABCDE') do
+          expect(page).to have_link 'ABCDE12345ABCDE'
+          expect(page).to have_content I18n.l(Date.current)
+          expect(page).to have_content '2 dias'
+          expect(page).to have_content 'R$ 25,00'
+          expect(page).to have_content 'Pendente'
+        end
+        within('#12345ABCDE12345') do
+          expect(page).to have_link '12345ABCDE12345'
+          expect(page).to have_content I18n.l(Date.current)
+          expect(page).to have_content '4 dias'
+          expect(page).to have_content 'R$ 50,00'
+          expect(page).to have_content 'Aceito'
+        end
       end
     end
   end

--- a/spec/system/orders/user_views_company_orders_spec.rb
+++ b/spec/system/orders/user_views_company_orders_spec.rb
@@ -28,9 +28,13 @@ describe 'Usuário vê pedidos da sua transportadora' do
     it 'com sucesso' do
       vehicle = create :vehicle, shipping_company: express
       allow(SecureRandom).to receive(:alphanumeric).and_return('ABCDE12345ABCDE')
-      create :order, shipping_company: express, estimated_delivery_time: 2, value: 2_500
+      create :order, shipping_company: express,
+                     estimated_delivery_time: 2,
+                     value: 2_500
       allow(SecureRandom).to receive(:alphanumeric).and_return('12345ABCDE12345')
-      create :order, shipping_company: express, estimated_delivery_time: 4, value: 5_000, status: :accepted,
+      create :order, shipping_company: express,
+                     estimated_delivery_time: 4, value: 5_000,
+                     status: :accepted,
                      vehicle: vehicle
 
       visit shipping_company_path(express)

--- a/spec/system/orders/user_views_order_details_spec.rb
+++ b/spec/system/orders/user_views_order_details_spec.rb
@@ -4,10 +4,9 @@ require 'rails_helper'
 
 describe 'Usuário visualiza detalhes de um pedido' do
   let!(:express) { create :express }
+  let!(:order) { create :order, shipping_company: express }
 
   it 'sem estar autenticado' do
-    order = create :order, shipping_company: express
-
     visit order_path(order)
 
     expect(page).to have_current_path new_user_session_path
@@ -16,7 +15,6 @@ describe 'Usuário visualiza detalhes de um pedido' do
 
   it 'com sucesso' do
     user = create :user, email: 'user@express.com.br'
-    order = create :order, shipping_company: express
 
     login_as user, scope: :user
     visit shipping_company_path(express)

--- a/spec/system/orders/user_views_order_details_spec.rb
+++ b/spec/system/orders/user_views_order_details_spec.rb
@@ -3,8 +3,18 @@
 require 'rails_helper'
 
 describe 'Usuário visualiza detalhes de um pedido' do
+  let!(:express) { create :express }
+
+  it 'sem estar autenticado' do
+    order = create :order, shipping_company: express
+
+    visit order_path(order)
+
+    expect(page).to have_current_path new_user_session_path
+    expect(page).to have_content 'Para continuar, faça login ou registre-se.'
+  end
+
   it 'com sucesso' do
-    express = create :express, email_domain: 'express.com.br'
     user = create :user, email: 'user@express.com.br'
     order = create :order, shipping_company: express
 
@@ -14,15 +24,5 @@ describe 'Usuário visualiza detalhes de um pedido' do
     click_on order.code
 
     expect(page).to have_current_path order_path(order)
-  end
-
-  it 'sem estar autenticado' do
-    express = create :express
-    order = create :order, shipping_company: express
-
-    visit order_path(order)
-
-    expect(page).to have_current_path new_user_session_path
-    expect(page).to have_content 'Para continuar, faça login ou registre-se.'
   end
 end

--- a/spec/system/orders/visitor_searches_for_order_spec.rb
+++ b/spec/system/orders/visitor_searches_for_order_spec.rb
@@ -3,8 +3,9 @@
 require 'rails_helper'
 
 describe 'Visitante busca status de pedido' do
+  let(:express) { create :express, corporate_name: 'Express Transportes Ltda.' }
+
   it 'informando seu código' do
-    express = create :express, corporate_name: 'Express Transportes Ltda.'
     vehicle = create :vehicle, shipping_company: express, license_plate: 'BRA3R52', brand: 'Fiat', model: 'Uno'
     order = create :order, :without_addresses, shipping_company: express, vehicle: vehicle, status: :accepted
     create :address, addressable: order, line1: 'Rua Rio Vermelho, n. 10', city: 'Natal', state: 'RN', kind: :pickup
@@ -27,7 +28,6 @@ describe 'Visitante busca status de pedido' do
   end
 
   it 'informando um código incorreto' do
-    express = create :express
     vehicle = create :vehicle, shipping_company: express
     allow(SecureRandom).to receive(:alphanumeric).and_return('12345EDCBAABCDE')
     create :order, shipping_company: express, vehicle: vehicle, status: :accepted
@@ -41,7 +41,6 @@ describe 'Visitante busca status de pedido' do
   end
 
   it 'que ainda não foi aceito' do
-    express = create :express
     order = create :order, shipping_company: express, status: :pending
 
     visit root_path
@@ -53,7 +52,6 @@ describe 'Visitante busca status de pedido' do
   end
 
   it 'que foi finalizado' do
-    express = create :express
     vehicle = create :vehicle, shipping_company: express
     order = create :order, shipping_company: express, vehicle: vehicle, status: :finished
 

--- a/spec/system/orders/visitor_searches_for_order_spec.rb
+++ b/spec/system/orders/visitor_searches_for_order_spec.rb
@@ -30,7 +30,9 @@ describe 'Visitante busca status de pedido' do
   it 'informando um código incorreto' do
     vehicle = create :vehicle, shipping_company: express
     allow(SecureRandom).to receive(:alphanumeric).and_return('12345EDCBAABCDE')
-    create :order, shipping_company: express, vehicle: vehicle, status: :accepted
+    create :order, shipping_company: express,
+                   vehicle: vehicle,
+                   status: :accepted
 
     visit root_path
     fill_in 'Código do pedido', with: 'ABCDE12345ABCDE'
@@ -53,7 +55,9 @@ describe 'Visitante busca status de pedido' do
 
   it 'que foi finalizado' do
     vehicle = create :vehicle, shipping_company: express
-    order = create :order, shipping_company: express, vehicle: vehicle, status: :finished
+    order = create :order, shipping_company: express,
+                           vehicle: vehicle,
+                           status: :finished
 
     visit root_path
     fill_in 'Código do pedido', with: order.code

--- a/spec/system/shipping_companies/admin_registers_shipping_company_spec.rb
+++ b/spec/system/shipping_companies/admin_registers_shipping_company_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Administrador cadastra transportadora' do
+describe 'Administrador cadastra transportadora,' do
   it 'sem se autenticar' do
     visit new_shipping_company_path
 
@@ -10,52 +10,50 @@ describe 'Administrador cadastra transportadora' do
     expect(page).to have_content 'Para continuar, faça login ou registre-se.'
   end
 
-  it 'com sucesso' do
-    admin = create :admin
+  context 'autenticado,' do
+    let(:admin) { create :admin }
 
-    login_as admin, scope: :admin
-    visit shipping_companies_path
-    click_on 'Cadastrar transportadora'
-    fill_in 'Nome fantasia', with: 'Express'
-    fill_in 'Razão social', with: 'Express Transportes Ltda.'
-    fill_in 'Domínio de e-mail', with: 'express.com.br'
-    fill_in 'CNPJ', with: '28891540000121'
-    fill_in 'Endereço', with: 'Avenida A, 10'
-    fill_in 'Cidade', with: 'Rio de Janeiro'
-    select 'RJ', from: 'Estado'
-    click_on 'Criar Transportadora'
+    before { login_as admin, scope: :admin }
 
-    expect(page).to have_current_path shipping_company_path(ShippingCompany.last)
-    expect(page).to have_content 'Transportadora cadastrada com sucesso.'
-    within('div#page_title') do
-      expect(page).to have_content 'Express'
+    it 'com sucesso' do
+      visit shipping_companies_path
+      click_on 'Cadastrar transportadora'
+      fill_in 'Nome fantasia', with: 'Express'
+      fill_in 'Razão social', with: 'Express Transportes Ltda.'
+      fill_in 'Domínio de e-mail', with: 'express.com.br'
+      fill_in 'CNPJ', with: '28891540000121'
+      fill_in 'Endereço', with: 'Avenida A, 10'
+      fill_in 'Cidade', with: 'Rio de Janeiro'
+      select 'RJ', from: 'Estado'
+      click_on 'Criar Transportadora'
+
+      expect(page).to have_current_path shipping_company_path(ShippingCompany.last)
+      expect(page).to have_content 'Transportadora cadastrada com sucesso.'
+      within('div#page_title') { expect(page).to have_content 'Express' }
+      within('section#company_details') do
+        expect(page).to have_content 'Nome fantasia: Express'
+        expect(page).to have_content 'Razão social: Express Transportes Ltda.'
+        expect(page).to have_content 'CNPJ: 28.891.540/0001-21'
+        expect(page).to have_content 'Domínio de e-mail: express.com.br'
+        expect(page).to have_content 'Endereço: Avenida A, 10 - Rio de Janeiro/RJ'
+      end
     end
-    within('section#company_details') do
-      expect(page).to have_content 'Nome fantasia: Express'
-      expect(page).to have_content 'Razão social: Express Transportes Ltda.'
-      expect(page).to have_content 'CNPJ: 28.891.540/0001-21'
-      expect(page).to have_content 'Domínio de e-mail: express.com.br'
-      expect(page).to have_content 'Endereço: Avenida A, 10 - Rio de Janeiro/RJ'
+
+    it 'com dados incompletos ou inválidos' do
+      visit new_shipping_company_path
+      fill_in 'Nome fantasia', with: 'Express'
+      fill_in 'CNPJ', with: '1234'
+      fill_in 'Domínio de e-mail', with: 'gmail.com!'
+      click_on 'Criar Transportadora'
+
+      expect(page).to have_current_path shipping_companies_path
+      expect(page).to have_content 'Transportadora não cadastrada.'
+      expect(page).to have_field 'Nome fantasia', with: 'Express'
+      expect(page).to have_content 'Razão social não pode ficar em branco'
+      expect(page).to have_content 'CNPJ não é válido'
+      expect(page).to have_content 'Domínio de e-mail não é válido'
+      expect(page).to have_content 'Endereço não pode ficar em branco'
+      expect(page).to have_content 'Cidade não pode ficar em branco'
     end
-  end
-
-  it 'com dados incompletos ou inválidos' do
-    admin = create :admin
-
-    login_as admin, scope: :admin
-    visit new_shipping_company_path
-    fill_in 'Nome fantasia', with: 'Express'
-    fill_in 'CNPJ', with: '1234'
-    fill_in 'Domínio de e-mail', with: 'gmail.com!'
-    click_on 'Criar Transportadora'
-
-    expect(page).to have_current_path shipping_companies_path
-    expect(page).to have_content 'Transportadora não cadastrada.'
-    expect(page).to have_field 'Nome fantasia', with: 'Express'
-    expect(page).to have_content 'Razão social não pode ficar em branco'
-    expect(page).to have_content 'CNPJ não é válido'
-    expect(page).to have_content 'Domínio de e-mail não é válido'
-    expect(page).to have_content 'Endereço não pode ficar em branco'
-    expect(page).to have_content 'Cidade não pode ficar em branco'
   end
 end

--- a/spec/system/shipping_companies/admin_views_shipping_companies_spec.rb
+++ b/spec/system/shipping_companies/admin_views_shipping_companies_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Administrador acessa o índice de transportadoras' do
+describe 'Administrador acessa o índice de transportadoras,' do
   it 'sem se autenticar' do
     visit shipping_companies_path
 
@@ -10,53 +10,54 @@ describe 'Administrador acessa o índice de transportadoras' do
     expect(page).to have_content 'Para continuar, faça login ou registre-se.'
   end
 
-  it 'e vê as transportadoras cadastradas' do
-    admin = create :admin
-    express = create :express, :without_address, brand_name: 'Express',
-                                                 corporate_name: 'Express Transportes Ltda.',
-                                                 email_domain: 'express.com.br',
-                                                 registration_number: 28_891_540_000_121
-    create :address, addressable: express, line1: 'Avenida A, 10', city: 'Rio de Janeiro', state: :RJ
-    a_jato = create :a_jato, :without_address, brand_name: 'A Jato',
-                                               corporate_name: 'A Jato S.A.',
-                                               email_domain: 'ajato.com',
-                                               registration_number: 19_824_380_000_107
-    create :address, addressable: a_jato, line1: 'Avenida B, 23', city: 'Natal', state: :RN
+  context 'autenticado,' do
+    let(:admin) { create :admin }
 
-    login_as admin, scope: :admin
-    visit root_path
-    click_on 'Transportadoras'
+    before { login_as admin, scope: :admin }
 
-    within('#table_header') do
-      expect(page).to have_content 'Nome fantasia'
-      expect(page).to have_content 'Razão social'
-      expect(page).to have_content 'Domínio de e-mail'
-      expect(page).to have_content 'CNPJ'
-      expect(page).to have_content 'Endereço'
+    it 'e vê as transportadoras cadastradas' do
+      express = create :express, :without_address, brand_name: 'Express',
+                                                   corporate_name: 'Express Transportes Ltda.',
+                                                   email_domain: 'express.com.br',
+                                                   registration_number: 28_891_540_000_121
+      create :address, addressable: express, line1: 'Avenida A, 10', city: 'Rio de Janeiro', state: :RJ
+      a_jato = create :a_jato, :without_address, brand_name: 'A Jato',
+                                                 corporate_name: 'A Jato S.A.',
+                                                 email_domain: 'ajato.com',
+                                                 registration_number: 19_824_380_000_107
+      create :address, addressable: a_jato, line1: 'Avenida B, 23', city: 'Natal', state: :RN
+
+      visit root_path
+      click_on 'Transportadoras'
+
+      within('#table_header') do
+        expect(page).to have_content 'Nome fantasia'
+        expect(page).to have_content 'Razão social'
+        expect(page).to have_content 'Domínio de e-mail'
+        expect(page).to have_content 'CNPJ'
+        expect(page).to have_content 'Endereço'
+      end
+      within('#Express') do
+        expect(page).to have_content 'Express'
+        expect(page).to have_content 'Express Transportes Ltda.'
+        expect(page).to have_content 'express.com.br'
+        expect(page).to have_content '28.891.540/0001-21'
+        expect(page).to have_content 'Avenida A, 10 - Rio de Janeiro/RJ'
+      end
+      within('#A_Jato') do
+        expect(page).to have_content 'A Jato'
+        expect(page).to have_content 'A Jato S.A.'
+        expect(page).to have_content 'ajato.com'
+        expect(page).to have_content '19.824.380/0001-07'
+        expect(page).to have_content 'Avenida B, 23 - Natal/RN'
+      end
     end
-    within('#Express') do
-      expect(page).to have_content 'Express'
-      expect(page).to have_content 'Express Transportes Ltda.'
-      expect(page).to have_content 'express.com.br'
-      expect(page).to have_content '28.891.540/0001-21'
-      expect(page).to have_content 'Avenida A, 10 - Rio de Janeiro/RJ'
+
+    it 'e não há transportadoras cadastradas' do
+      visit shipping_companies_path
+
+      expect(page).to have_content 'Não existem transportadoras cadastradas.'
+      expect(page).not_to have_table 'shipping_companies'
     end
-    within('#A_Jato') do
-      expect(page).to have_content 'A Jato'
-      expect(page).to have_content 'A Jato S.A.'
-      expect(page).to have_content 'ajato.com'
-      expect(page).to have_content '19.824.380/0001-07'
-      expect(page).to have_content 'Avenida B, 23 - Natal/RN'
-    end
-  end
-
-  it 'e não há transportadoras cadastradas' do
-    admin = create :admin
-
-    login_as admin, scope: :admin
-    visit shipping_companies_path
-
-    expect(page).to have_content 'Não existem transportadoras cadastradas.'
-    expect(page).not_to have_table 'shipping_companies'
   end
 end

--- a/spec/system/shipping_companies/admin_views_shipping_companies_spec.rb
+++ b/spec/system/shipping_companies/admin_views_shipping_companies_spec.rb
@@ -20,12 +20,18 @@ describe 'Administrador acessa o índice de transportadoras,' do
                                                    corporate_name: 'Express Transportes Ltda.',
                                                    email_domain: 'express.com.br',
                                                    registration_number: 28_891_540_000_121
-      create :address, addressable: express, line1: 'Avenida A, 10', city: 'Rio de Janeiro', state: :RJ
+      create :address, addressable: express,
+                       line1: 'Avenida A, 10',
+                       city: 'Rio de Janeiro',
+                       state: :RJ
       a_jato = create :a_jato, :without_address, brand_name: 'A Jato',
                                                  corporate_name: 'A Jato S.A.',
                                                  email_domain: 'ajato.com',
                                                  registration_number: 19_824_380_000_107
-      create :address, addressable: a_jato, line1: 'Avenida B, 23', city: 'Natal', state: :RN
+      create :address, addressable: a_jato,
+                       line1: 'Avenida B, 23',
+                       city: 'Natal',
+                       state: :RN
 
       visit root_path
       click_on 'Transportadoras'

--- a/spec/system/shipping_companies/user_views_shipping_company_details_spec.rb
+++ b/spec/system/shipping_companies/user_views_shipping_company_details_spec.rb
@@ -24,9 +24,7 @@ describe 'Usuário acessa a tela de detalhes da sua transportadora' do
     visit root_path
     click_on 'Express'
 
-    within('div#page_title') do
-      expect(page).to have_content 'Express'
-    end
+    within('div#page_title') { expect(page).to have_content 'Express' }
     within('section#company_details') do
       expect(page).to have_content 'Nome fantasia: Express'
       expect(page).to have_content 'Razão social: Express Transportes Ltda.'

--- a/spec/system/shipping_companies/user_views_shipping_company_details_spec.rb
+++ b/spec/system/shipping_companies/user_views_shipping_company_details_spec.rb
@@ -17,7 +17,10 @@ describe 'Usuário acessa a tela de detalhes da sua transportadora' do
                                                  corporate_name: 'Express Transportes Ltda.',
                                                  registration_number: 28_891_540_000_121,
                                                  email_domain: 'express.com.br'
-    create :address, addressable: express, line1: 'Avenida A, 10', city: 'Natal', state: :RN
+    create :address, addressable: express,
+                     line1: 'Avenida A, 10',
+                     city: 'Natal',
+                     state: :RN
     user = create :user, email: 'usuario@express.com.br'
 
     login_as user, scope: :user

--- a/spec/system/vehicles/user_registers_company_vehicle_spec.rb
+++ b/spec/system/vehicles/user_registers_company_vehicle_spec.rb
@@ -47,7 +47,7 @@ describe 'Usuário cadastra veículo' do
     expect(page).to have_current_path shipping_company_vehicles_path(express)
     expect(page).to have_content 'Veículo não cadastrado.'
     expect(page).to have_field 'Modelo', with: 'Uno'
-    expect(page).to have_content 'Placa de identificação não é válido'
+    expect(page).to have_content 'Placa de identificação não pode ficar em branco'
     expect(page).to have_content 'Marca não pode ficar em branco'
     expect(page).to have_content 'Ano de produção não pode ficar em branco'
     expect(page).to have_content 'Carga máxima não pode ficar em branco'

--- a/spec/system/vehicles/user_registers_company_vehicle_spec.rb
+++ b/spec/system/vehicles/user_registers_company_vehicle_spec.rb
@@ -2,72 +2,66 @@
 
 require 'rails_helper'
 
-describe 'Usuário cadastra veículo' do
-  it 'sem se autenticar' do
-    express = create :express
+describe 'Usuário cadastra veículo,' do
+  let!(:express) { create :express }
+  let(:user) { create :user }
 
+  it 'sem se autenticar' do
     visit new_shipping_company_vehicle_path(express)
 
     expect(page).to have_current_path new_user_session_path
     expect(page).to have_content 'Para continuar, faça login ou registre-se.'
   end
 
-  it 'com sucesso' do
-    express = create :express
-    user = create :user
+  context 'autenticado' do
+    before { login_as user, scope: :user }
 
-    login_as user, scope: :user
-    visit shipping_company_path(express)
-    click_on 'Cadastrar veículo'
-    fill_in 'Placa de identificação', with: 'BRA3R52'
-    fill_in 'Modelo', with: 'Uno'
-    fill_in 'Marca', with: 'Fiat'
-    fill_in 'Ano de produção', with: '1992'
-    fill_in 'Carga máxima', with: '100000'
-    click_on 'Criar Veículo'
+    it 'com sucesso' do
+      visit shipping_company_path(express)
+      click_on 'Cadastrar veículo'
+      fill_in 'Placa de identificação', with: 'BRA3R52'
+      fill_in 'Modelo', with: 'Uno'
+      fill_in 'Marca', with: 'Fiat'
+      fill_in 'Ano de produção', with: '1992'
+      fill_in 'Carga máxima', with: '100000'
+      click_on 'Criar Veículo'
 
-    expect(page).to have_current_path shipping_company_path(express)
-    expect(page).to have_content 'Veículo cadastrado com sucesso.'
-    expect(page).to have_content 'BRA3R52'
-    expect(page).to have_content 'Fiat'
-    expect(page).to have_content 'Uno'
-    expect(page).to have_content '1992'
-    expect(page).to have_content '100 kg'
-  end
+      expect(page).to have_current_path shipping_company_path(express)
+      expect(page).to have_content 'Veículo cadastrado com sucesso.'
+      expect(page).to have_content 'BRA3R52'
+      expect(page).to have_content 'Fiat'
+      expect(page).to have_content 'Uno'
+      expect(page).to have_content '1992'
+      expect(page).to have_content '100 kg'
+    end
 
-  it 'com dados incompletos' do
-    express = create :express
-    user = create :user
+    it 'com dados incompletos' do
+      visit new_shipping_company_vehicle_path(express)
+      fill_in 'Modelo', with: 'Uno'
+      click_on 'Criar Veículo'
 
-    login_as user, scope: :user
-    visit new_shipping_company_vehicle_path(express)
-    fill_in 'Modelo', with: 'Uno'
-    click_on 'Criar Veículo'
+      expect(page).to have_current_path shipping_company_vehicles_path(express)
+      expect(page).to have_content 'Veículo não cadastrado.'
+      expect(page).to have_field 'Modelo', with: 'Uno'
+      expect(page).to have_content 'Placa de identificação não pode ficar em branco'
+      expect(page).to have_content 'Marca não pode ficar em branco'
+      expect(page).to have_content 'Ano de produção não pode ficar em branco'
+      expect(page).to have_content 'Carga máxima não pode ficar em branco'
+    end
 
-    expect(page).to have_current_path shipping_company_vehicles_path(express)
-    expect(page).to have_content 'Veículo não cadastrado.'
-    expect(page).to have_field 'Modelo', with: 'Uno'
-    expect(page).to have_content 'Placa de identificação não pode ficar em branco'
-    expect(page).to have_content 'Marca não pode ficar em branco'
-    expect(page).to have_content 'Ano de produção não pode ficar em branco'
-    expect(page).to have_content 'Carga máxima não pode ficar em branco'
-  end
+    it 'com dados inválidos ou repetidos' do
+      create :vehicle, shipping_company: express, license_plate: 'BRA3R52'
 
-  it 'com dados inválidos ou repetidos' do
-    express = create :express
-    user = create :user
-    create :vehicle, shipping_company: express, license_plate: 'BRA3R52'
+      visit new_shipping_company_vehicle_path(express)
+      fill_in 'Placa de identificação', with: 'BRA3R52'
+      fill_in 'Ano de produção', with: 1.year.from_now.year
+      fill_in 'Carga máxima', with: '0'
+      click_on 'Criar Veículo'
 
-    login_as user, scope: :user
-    visit new_shipping_company_vehicle_path(express)
-    fill_in 'Placa de identificação', with: 'BRA3R52'
-    fill_in 'Ano de produção', with: 1.year.from_now.year
-    fill_in 'Carga máxima', with: '0'
-    click_on 'Criar Veículo'
-
-    expect(page).to have_current_path shipping_company_vehicles_path(express)
-    expect(page).to have_content 'Placa de identificação já está em uso'
-    expect(page).to have_content 'Ano de produção deve estar entre 1908 e o ano atual'
-    expect(page).to have_content 'Carga máxima deve ser maior que 0'
+      expect(page).to have_current_path shipping_company_vehicles_path(express)
+      expect(page).to have_content 'Placa de identificação já está em uso'
+      expect(page).to have_content 'Ano de produção deve estar entre 1908 e o ano atual'
+      expect(page).to have_content 'Carga máxima deve ser maior que 0'
+    end
   end
 end

--- a/spec/system/vehicles/user_views_company_vehicles_spec.rb
+++ b/spec/system/vehicles/user_views_company_vehicles_spec.rb
@@ -3,15 +3,25 @@
 require 'rails_helper'
 
 describe 'Usuário acessa a página de detalhes de uma transportadora' do
-  it 'e vê os veículos cadastrados' do
-    express = create :express
-    user = create :user
-    create :vehicle, license_plate: 'BRA3R52', brand: 'Fiat', model: 'Uno', production_year: 1992,
-                     maximum_load: 100_000, shipping_company: express
-    create :vehicle, license_plate: 'ARG4523', brand: 'Volkswagen', model: 'Fusca', production_year: 1971,
-                     maximum_load: 40_000, shipping_company: express
+  let!(:express) { create :express }
+  let(:user) { create :user }
 
-    login_as user, scope: :user
+  before { login_as user, scope: :user }
+
+  it 'e vê os veículos cadastrados' do
+    create :vehicle, license_plate: 'BRA3R52',
+                     brand: 'Fiat',
+                     model: 'Uno',
+                     production_year: 1992,
+                     maximum_load: 100_000,
+                     shipping_company: express
+    create :vehicle, license_plate: 'ARG4523',
+                     brand: 'Volkswagen',
+                     model: 'Fusca',
+                     production_year: 1971,
+                     maximum_load: 40_000,
+                     shipping_company: express
+
     visit shipping_company_path(express)
 
     expect(page).to have_content 'Veículos cadastrados'
@@ -41,10 +51,6 @@ describe 'Usuário acessa a página de detalhes de uma transportadora' do
   end
 
   it 'e não há veículos cadastrados' do
-    express = create :express
-    user = create :user
-
-    login_as user, scope: :user
     visit shipping_company_path(express)
 
     expect(page).to have_content 'Não existem veículos cadastrados.'

--- a/spec/system/visitor_views_homepage_spec.rb
+++ b/spec/system/visitor_views_homepage_spec.rb
@@ -3,32 +3,23 @@
 require 'rails_helper'
 
 describe 'Visitante acessa a página inicial' do
-  it 'e vê os links de autenticação' do
-    visit root_path
+  subject { page }
 
-    expect(page).to have_content 'SISTEMA DE GERENCIAMENTO DE ENTREGAS'
-    expect(page).to have_link 'Entrar (usuário)'
-    expect(page).to have_link 'Entrar (administrador)'
-  end
+  before { visit root_path }
+
+  it { is_expected.to have_content 'SISTEMA DE GERENCIAMENTO DE ENTREGAS' }
+  it { is_expected.to have_link 'Entrar (usuário)' }
+  it { is_expected.to have_link 'Entrar (administrador)' }
+  it { is_expected.to have_content 'Consultar status de entrega' }
+  it { is_expected.to have_field 'Código do pedido' }
+  it { is_expected.to have_button 'Consultar' }
 
   it 'e vê o menu de navegação' do
-    create :express, brand_name: 'Express'
-
-    visit root_path
-
     within('nav') do
       expect(page).to have_link 'Início'
       expect(page).not_to have_link 'Transportadoras'
       expect(page).not_to have_link 'Express'
       expect(page).not_to have_button 'Sair'
     end
-  end
-
-  it 'e vê a busca de pedidos' do
-    visit root_path
-
-    expect(page).to have_content 'Consultar status de entrega'
-    expect(page).to have_field 'Código do pedido'
-    expect(page).to have_button 'Consultar'
   end
 end


### PR DESCRIPTION
# Resolve #28 

## Motivação
- Com a adição da _gem_ **shoulda-matchers** ao projeto, testes antigos podem ser refatorados, tornando-se mais claros e enxutos.

## Solução proposta
- Refatoração dos testes para uso da _gem_, particularmente nos testes unitários de _models_;
- Uso de **let**, **before** e **subject** para atender ao princípio DRY em situações nas quais isso não piora notavelmente a legibilidade dos testes.

## Critérios para aceite
- [x] Testes devem continuar passando;
- [x] Refatoração não deve prejudicar legibilidade;
- [x]  Performance dos testes não pode piorar.

## Tarefas
- [x] Refatorar testes de _models_;
- [x] Refatorar testes de sistema.

## Links
- [**Rspec style guide**](https://rspec.rubystyle.guide/)
- [**Shoulda-matchers: documentação**](https://matchers.shoulda.io/docs/v5.1.0/)